### PR TITLE
EID-745: Add acceptance tests without JavaScript and print test report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-tmp/capybara
+testreport

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'features/step_definitions/user_steps.rb'
+    - 'features/support/env.rb'
+
+Metrics/LineLength:
+  Max: 130
+  Exclude:
+    - 'features/support/env.rb'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN bundle install
 
 COPY features /features
 
-ENTRYPOINT ["bundle", "exec", "cucumber"]
+ENTRYPOINT ["bundle", "exec", "cucumber --strict"]

--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -2,11 +2,39 @@ Feature: User account creation
 
   This tests user account creation flows.
 
-  @javascript
+  @no_javascript
+  Scenario: Registration and cycle 3 without JavaScript
+    Given the user is at Test RP
+    And we do not want to match the user
+    And they start a journey
+    And they continue to the next step
+    And they continue to a Verify registration journey
+    And they have all their documents
+    And they do not have a phone
+    And they register with "Stub Idp Demo"
+    And they continue to the next step
+    And they enter user details:
+      | firstname       | Jane       |
+      | surname         | Doe        |
+      | addressLine1    | 123        |
+      | addressLine2    | Test Drive |
+      | addressTown     | Marlbury   |
+      | addressPostCode | ABC 123    |
+      | dateOfBirth     | 1987-03-03 |
+    And they continue to the next step
+    And they click Continue
+    And they submit cycle 3 "AA123456A"
+    And they continue to the next step
+    Then a user should have been created with details:
+      | firstname   | Jane       |
+      | surname     | Doe        |
+      | dateofbirth | 1987-03-03 |
+
   Scenario: Registration and cycle 3
     Given the user is at Test RP
     And we do not want to match the user
-    And they start a registration journey
+    And they start a journey
+    And they continue to a Verify registration journey
     And they have all their documents
     And they do not have a phone
     And they register with "Stub Idp Demo"
@@ -18,17 +46,36 @@ Feature: User account creation
       | addressTown     | Marlbury   |
       | addressPostCode | ABC 123    |
       | dateOfBirth     | 1987-03-03 |
+    And they click Continue
     And they submit cycle 3 "AA123456A"
     Then a user should have been created with details:
       | firstname   | Jane       |
       | surname     | Doe        |
       | dateofbirth | 1987-03-03 |
 
-  @javascript
+  @no_javascript
+  Scenario: Sign in and cycle 3 without JavaScript
+    Given the user is at Test RP
+    And we do not want to match the user
+    And they start a journey
+    And they continue to the next step
+    And they continue to a Verify sign-in journey
+    And they select IDP "Stub Idp Demo"
+    And they continue to the next step
+    And they login as "stub-idp-demo"
+    And they continue to the next step
+    And they submit cycle 3 "AA123456A"
+    And they continue to the next step
+    Then a user should have been created with details:
+      | firstname   | Jack       |
+      | surname     | Bauer      |
+      | dateofbirth | 1984-02-29 |
+
   Scenario: Sign in and cycle 3
     Given the user is at Test RP
     And we do not want to match the user
-    And they start a sign in journey
+    And they start a journey
+    And they continue to a Verify sign-in journey
     And they select IDP "Stub Idp Demo"
     And they login as "stub-idp-demo"
     And they submit cycle 3 "AA123456A"
@@ -37,12 +84,40 @@ Feature: User account creation
       | surname     | Bauer      |
       | dateofbirth | 1984-02-29 |
 
-  @javascript
+  @no_javascript
+  Scenario: Registration without cycle 3 without JavaScript
+    Given the user is at Test RP
+    And we set the RP name to "test-rp-noc3"
+    And we do not want to match the user
+    And they start a journey
+    And they continue to the next step
+    And they continue to a Verify registration journey
+    And they have all their documents
+    And they do not have a phone
+    And they register with "Stub Idp Demo"
+    And they continue to the next step
+    And they enter user details:
+      | firstname       | Jane       |
+      | surname         | Doe        |
+      | addressLine1    | 123        |
+      | addressLine2    | Test Drive |
+      | addressTown     | Marlbury   |
+      | addressPostCode | ABC 123    |
+      | dateOfBirth     | 1987-03-03 |
+    And they continue to the next step
+    And they click Continue
+    And they continue to the next step
+    Then a user should have been created with details:
+      | firstname   | Jane       |
+      | surname     | Doe        |
+      | dateofbirth | 1987-03-03 |
+
   Scenario: Registration without cycle 3
     Given the user is at Test RP
     And we set the RP name to "test-rp-noc3"
     And we do not want to match the user
-    And they start a registration journey
+    And they start a journey
+    And they continue to a Verify registration journey
     And they have all their documents
     And they do not have a phone
     And they register with "Stub Idp Demo"
@@ -54,18 +129,36 @@ Feature: User account creation
       | addressTown     | Marlbury   |
       | addressPostCode | ABC 123    |
       | dateOfBirth     | 1987-03-03 |
+    And they click Continue
     Then a user should have been created with details:
       | firstname   | Jane       |
       | surname     | Doe        |
       | dateofbirth | 1987-03-03 |
 
+  @no_javascript
+  Scenario: Sign in without cycle 3 without JavaScript
+    Given the user is at Test RP
+    And we set the RP name to "test-rp-noc3"
+    And we do not want to match the user
+    And they start a journey
+    And they continue to the next step
+    And they continue to a Verify sign-in journey
+    And they select IDP "Stub Idp Demo"
+    And they continue to the next step
+    And they login as "stub-idp-demo"
+    And they continue to the next step
+    And they continue to the next step
+    Then a user should have been created with details:
+      | firstname   | Jack       |
+      | surname     | Bauer      |
+      | dateofbirth | 1984-02-29 |
 
-  @javascript
   Scenario: Sign in without cycle 3
     Given the user is at Test RP
     And we set the RP name to "test-rp-noc3"
     And we do not want to match the user
-    And they start a sign in journey
+    And they start a journey
+    And they continue to a Verify sign-in journey
     And they select IDP "Stub Idp Demo"
     And they login as "stub-idp-demo"
     Then a user should have been created with details:
@@ -73,14 +166,13 @@ Feature: User account creation
       | surname     | Bauer      |
       | dateofbirth | 1984-02-29 |
 
-
-  @javascript
   Scenario: Failed user account creation
     Given the user is at Test RP
     And we set the RP name to "test-rp-noc3"
     And we do not want to match the user
     And we want to fail account creation
-    And they start a sign in journey
+    And they start a journey
+    And they continue to a Verify sign-in journey
     And they select IDP "Stub Idp Demo"
     And they login as "stub-idp-demo" with a random pid
     Then user account creation should fail

--- a/features/eidas_user_journeys.feature
+++ b/features/eidas_user_journeys.feature
@@ -2,7 +2,19 @@ Feature: eIDAS user journeys
 
   This tests eIDAS end-to-end journeys in the Verify Hub via the Rails frontend.
 
-  @javascript
+  @no_javascript
+  Scenario: User signs in with a country without JavaScript
+    Given the user is at Test RP
+    When they start a journey
+    And they continue to the next step
+    And they choose to use a European identity scheme
+    And they select IDP "Stub IDP Demo"
+    And they continue to the next step
+    And they login as "stub-country"
+    And they continue to the next step
+    And they continue to the next step
+    Then they should be successfully verified
+
   Scenario: User signs in with a country
     Given the user is at Test RP
     And they start an eIDAS journey
@@ -10,7 +22,6 @@ Feature: eIDAS user journeys
     And they login as "stub-country"
     Then they should be successfully verified
 
-  @javascript
   Scenario: User with accents in name signs in
     Given the user is at Test RP
     And they start an eIDAS journey
@@ -18,7 +29,6 @@ Feature: eIDAS user journeys
     And they login as "stub-country-accents"
     Then they should be successfully verified
 
-  @javascript
   Scenario: User with non-Latin name signs in
     Given the user is at Test RP
     And they start an eIDAS journey
@@ -26,7 +36,20 @@ Feature: eIDAS user journeys
     And they login as "stub-country-nonlatin"
     Then they should be successfully verified
 
-  @javascript
+  @no_javascript
+  Scenario: User signs in with a country and does Cycle 3 without JavaScript
+    Given the user is at Test RP
+    When they start a journey
+    And they continue to the next step
+    And they choose to use a European identity scheme
+    And they select IDP "Stub IDP Demo"
+    And they continue to the next step
+    And they login as "stub-country-ec3"
+    And they continue to the next step
+    And they submit cycle 3 "AA123456A"
+    And they continue to the next step
+    Then they should be successfully verified
+
   Scenario: User signs in with a country and does Cycle 3
     Given the user is at Test RP
     And they start an eIDAS journey
@@ -35,7 +58,28 @@ Feature: eIDAS user journeys
     And they submit cycle 3 "AA123456A"
     Then they should be successfully verified
 
-  @javascript
+  @no_javascript
+  Scenario: User registers with stub country, with cycle3 and forces UAC without JavaScript
+    Given the user is at Test RP
+    And we do not want to match the user
+    And they start a journey
+    And they continue to the next step
+    And they choose to use a European identity scheme
+    And they select IDP "Stub IDP Demo"
+    And they continue to the next step
+    And they click Register
+    And they enter eidas user details:
+      | firstname   | Bob        |
+      | surname     | Doe        |
+      | dateOfBirth | 1987-03-03 |
+    And they continue to the next step
+    And they submit cycle 3 "AA123456A"
+    And they continue to the next step
+    Then a user should have been created with details:
+      | firstname   | Bob        |
+      | surname     | Doe        |
+      | dateofbirth | 1987-03-03 |
+
   Scenario: User registers with stub country, with cycle3 and forces UAC
     Given the user is at Test RP
     And we do not want to match the user
@@ -52,8 +96,25 @@ Feature: eIDAS user journeys
       | surname     | Doe        |
       | dateofbirth | 1987-03-03 |
 
-  @javascript
-  Scenario: User signs creates a new account
+  @no_javascript
+  Scenario: User creates a new account without JavaScript
+    Given the user is at Test RP
+    And we do not want to match the user
+    And they start a journey
+    And they continue to the next step
+    And they choose to use a European identity scheme
+    And they select IDP "Stub IDP Demo"
+    And they continue to the next step
+    And they login as "stub-country"
+    And they continue to the next step
+    And they submit cycle 3 "AA123456A"
+    And they continue to the next step
+    Then a user should have been created with details:
+      | firstname   | Jack       |
+      | surname     | Bauer      |
+      | dateofbirth | 1984-02-29 |
+
+  Scenario: User creates a new account
     Given the user is at Test RP
     And we do not want to match the user
     And they start an eIDAS journey

--- a/features/journey_picker.feature
+++ b/features/journey_picker.feature
@@ -4,21 +4,25 @@ Feature: Page to pick between Verify and eIDAS journies
   Verify and eIDAS when there is no journey hint supplied and
   the service has eIDAS enabled.
 
-  @javascript
+  @no_javascript
+  Scenario: Start a journey without JavaScript
+    Given the user is at Test RP
+    When they start a journey
+    And they continue to the next step
+    Then they arrive at the journey picker page
+
   Scenario: Verify button on picker page goes to Start page
     Given the user is at Test RP
     When they start a journey
     And they choose to use Verify
     Then they arrive at the Start page
 
-  @javascript
   Scenario: eIDAS button on picker page goes to country picker
     Given the user is at Test RP
     When they start a journey
     And they choose to use a European identity scheme
     Then they arrive at the country picker
 
-  @javascript
   Scenario: RP without eIDAS enabled doesn't trigger picker
     Given the user is at Test RP
     And we set the RP name to "test-rp-non-eidas"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -13,38 +13,35 @@ def see_journey_picker?
   @see_journey_picker
 end
 
-Given("the user is at Test RP") do
+Given('the user is at Test RP') do
   visit(env('test-rp'))
   @see_journey_picker = true
 end
 
-Given("we do not want to match the user") do
+Given('we do not want to match the user') do
   check('no-match')
 end
 
-Given("we want to fail account creation") do
+Given('we want to fail account creation') do
   check('fail-account-creation')
 end
 
-Given("we set the RP name to {string}") do |name|
+Given('we set the RP name to {string}') do |name|
   fill_in('rp-name', with: name)
   @see_journey_picker = false
 end
 
-Given("they start a journey") do
+Given('they start a journey') do
   click_on('Start')
 end
 
-Given("they start a sign in journey") do
-  click_on('Start')
+Given('they continue to a Verify sign-in journey') do
   click_on('Use GOV.UK Verify') if see_journey_picker?
   choose('start_form_selection_false')
   click_on('Continue')
 end
 
-Given("they start a registration journey") do
-  click_on('Start')
-
+Given('they continue to a Verify registration journey') do
   click_on('Use GOV.UK Verify') if see_journey_picker?
   choose('start_form_selection_true')
   click_on('Continue')
@@ -58,39 +55,43 @@ Given("they start a registration journey") do
   click_on('Continue')
 end
 
-Given("they start an eIDAS journey") do
+Given('they start an eIDAS journey') do
   click_on('Start')
   click_on('Select your European digital identity')
 end
 
-When("they choose to use Verify") do
+When('they choose to use Verify') do
   click_on('Use GOV.UK Verify')
 end
 
-When("they choose to use a European identity scheme") do
-  click_on("Select your European digital identity")
+When('they choose to use a European identity scheme') do
+  click_on('Select your European digital identity')
 end
 
-Given("they select eIDAS scheme {string}") do |string|
+Given('they select eIDAS scheme {string}') do |string|
   click_on('Select ' + string)
 end
 
-Given("they click Register") do
+Given('they click Register') do
   click_on('Register')
 end
 
-Given("they go back to the country picker") do
+Given('they click Continue') do
+  click_on('Continue')
+end
+
+Given('they go back to the country picker') do
   visit(URI.join(env('frontend'), 'choose-a-country'))
 end
 
-Given("they login as {string}") do |username|
+Given('they login as {string}') do |username|
   fill_in('username', with: username)
   fill_in('password', with: 'bar')
   click_on('SignIn')
   click_on('I Agree')
 end
 
-Given("they login as {string} with a random pid") do |username|
+Given('they login as {string} with a random pid') do |username|
   fill_in('username', with: username)
   fill_in('password', with: 'bar')
   click_on('SignIn')
@@ -99,39 +100,50 @@ Given("they login as {string} with a random pid") do |username|
   click_on('I Agree')
 end
 
-Given("they submit cycle 3 {string}") do |string|
+Given('they submit cycle 3 {string}') do |string|
   fill_in('cycle_three_attribute[cycle_three_data]', with: string)
   click_on('Continue')
 end
 
-Given("they have all their documents") do
+Given('they have all their documents') do
   choose('select_documents_form_any_driving_licence_true')
   choose('Great Britain')
   choose('select_documents_form_passport_true')
   click_on('Continue')
 end
 
-Given("they have a smart phone") do
+Given('they have a smart phone') do
   choose('select_phone_form_mobile_phone_true')
   choose('select_phone_form_smart_phone_true')
   click_on('Continue')
 end
 
-Given("they do not have a phone") do
+Given('they do not have a phone') do
   choose('select_phone_form_mobile_phone_false')
   click_on('Continue')
 end
 
-Given("they register with {string}") do |idp|
+Given('they register with {string}') do |idp|
   click_on("Choose #{idp}")
   click_on("Continue to the #{idp} website")
 end
 
-Given("they select IDP {string}") do |idp|
+Given('they select IDP {string}') do |idp|
   click_on("Select #{idp}", match: :first)
 end
 
-Given("they enter user details:") do |details|
+Given('they enter user details:') do |details|
+  details.rows_hash.each do |input, value|
+    fill_in(input, with: value)
+  end
+
+  fill_in('username', with: SecureRandom.hex)
+  fill_in('password', with: 'bar')
+  click_on('Register')
+  click_on('I Agree')
+end
+
+Given('they enter eidas user details:') do |details|
   details.rows_hash.each do |input, value|
     fill_in(input, with: value)
   end
@@ -141,32 +153,24 @@ Given("they enter user details:") do |details|
   click_on('Register')
   click_on('I Agree')
 
+end
+
+Given('they continue to the next step') do
+  assert_text('Continue to next step')
   click_on('Continue')
 end
 
-Given("they enter eidas user details:") do |details|
-  details.rows_hash.each do |input, value|
-    fill_in(input, with: value)
-  end
-
-  fill_in('username', with: SecureRandom.hex)
-  fill_in('password', with: 'bar')
-  click_on('Register')
-  click_on('I Agree')
-
-end
-
-Then("they should be at IDP {string}") do |idp|
+Then('they should be at IDP {string}') do |idp|
   page = env('idps').fetch(idp)
   assert_current_path(page, url: true)
 end
 
-Then("they should be successfully verified") do
+Then('they should be successfully verified') do
   find('.success-notice')
   assert_text('Your identity has been confirmed')
 end
 
-Then("a user should have been created with details:") do |details|
+Then('a user should have been created with details:') do |details|
   assert_text('Your user account has been created')
 
   details.rows_hash.each do |k, v|
@@ -174,8 +178,8 @@ Then("a user should have been created with details:") do |details|
   end
 end
 
-Then("user account creation should fail") do
-  assert_text("Sorry, something went wrong")
+Then('user account creation should fail') do
+  assert_text('Sorry, something went wrong')
 end
 
 Then('they arrive at the Start page') do
@@ -183,5 +187,13 @@ Then('they arrive at the Start page') do
 end
 
 Then('they arrive at the country picker') do
+  assert_text('Use a digital identity from another European country')
+  assert_text('You can use a digital identity from another European country to access services on GOV.UK.')
+end
+
+Then('they arrive at the journey picker page') do
+  assert_text('Prove your identity to continue')
+  assert_text('Choose how you want to prove your identity so you can register for an identity profile.')
+  assert_text('Use GOV.UK Verify')
   assert_text('Use a digital identity from another European country')
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -25,22 +25,22 @@ if ENV['TEST_ENV'] == "local" || ENV['SHOW_BROWSER']
     Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
   end
 else
+  selenium_hub_url = "http://selenium-hub:4444/wd/hub"
   Capybara.register_driver "selenium_remote_firefox".to_sym do |app|
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: "http://selenium-hub:4444/wd/hub", desired_capabilities: :firefox)
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox)
   end
 
   Capybara.javascript_driver = :selenium_remote_firefox
 
   Capybara.register_driver no_javascript_driver do |app|
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: "http://selenium-hub:4444/wd/hub", desired_capabilities: :firefox, options: options)
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox, options: options)
   end
 end
 
 #Screenshot config
 ## screenshots saved under test name + date
-Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |example|
-  puts "Example object: #{example.name}"
-  "screenshot_#{example.name.gsub(' ', '-').gsub(/^.*\/spec\//, '')}"
+Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |failing_test|
+  "screenshot_#{failing_test.name.tr(' ', '-').gsub(/^.*\/spec\//, '')}"
 end
 
 ## dynamically register javascript screenshot driver
@@ -56,6 +56,6 @@ end
 ## default host to assist in rendering
 Capybara.asset_host = 'http://localhost:3000'
 ## host directory for screenshot files
-Capybara.save_path = "tmp/capybara"
+Capybara.save_path = "testreport/"
 # Keep only the screenshots generated from the last failing test suite
 Capybara::Screenshot.prune_strategy = :keep_last_run

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,41 +6,49 @@ Capybara.configure do |cfg|
   cfg.default_max_wait_time = 20
 end
 
+show_browser = ENV['SHOW_BROWSER'] == 'true'
+
 no_javascript_driver = :no_javascript
 
-if ENV['TEST_ENV'] == "local" || ENV['SHOW_BROWSER']
+no_javascript_options = ::Selenium::WebDriver::Firefox::Options.new
+no_javascript_options.args << '--headless' unless show_browser
+no_javascript_options.add_preference('javascript.enabled', false)
+
+### Driver config ###
+
+if ENV['TEST_ENV'] == 'local' || ENV['SHOW_BROWSER']
   Capybara.register_driver :firefox_headless do |app|
     options = ::Selenium::WebDriver::Firefox::Options.new
     options.args << '--headless'
 
     Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
   end
-  Capybara.javascript_driver = :firefox_headless unless ENV['SHOW_BROWSER'] == 'true'
 
-  Capybara.register_driver no_javascript_driver do |app|
-    options = ::Selenium::WebDriver::Firefox::Options.new
-    options.args << '--headless'
-    options.add_preference('javascript.enabled', false)
+  Capybara.javascript_driver = :firefox_headless unless show_browser
 
-    Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+  Capybara.register_driver :no_javascript do |app|
+    Capybara::Selenium::Driver.new(app, browser: :firefox, options: no_javascript_options)
   end
 else
-  selenium_hub_url = "http://selenium-hub:4444/wd/hub"
-  Capybara.register_driver "selenium_remote_firefox".to_sym do |app|
+  selenium_hub_url = 'http://selenium-hub:4444/wd/hub'
+  Capybara.register_driver 'selenium_remote_firefox'.to_sym do |app|
     Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox)
   end
 
   Capybara.javascript_driver = :selenium_remote_firefox
 
-  Capybara.register_driver no_javascript_driver do |app|
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox, options: options)
+  Capybara.register_driver :no_javascript do |app|
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox, options: no_javascript_options)
   end
 end
 
-#Screenshot config
+Capybara.default_driver = Capybara.javascript_driver
+
+### Screenshot config ###
+
 ## screenshots saved under test name + date
 Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |failing_test|
-  "screenshot_#{failing_test.name.tr(' ', '-').gsub(/^.*\/spec\//, '')}"
+  "screenshot_#{failing_test.name.tr(' ', '-').gsub(%r{^.*\/spec\/}, '')}"
 end
 
 ## dynamically register javascript screenshot driver
@@ -48,14 +56,16 @@ Capybara::Screenshot.register_driver(Capybara.javascript_driver) do |driver, pat
   driver.browser.save_screenshot(path)
 end
 
-## dynamically register nojavascript screenshot driver
+## dynamically register no_javascript screenshot driver
 Capybara::Screenshot.register_driver(no_javascript_driver) do |driver, path|
   driver.browser.save_screenshot(path)
 end
 
 ## default host to assist in rendering
 Capybara.asset_host = 'http://localhost:3000'
+
 ## host directory for screenshot files
-Capybara.save_path = "testreport/"
+Capybara.save_path = 'testreport/'
+
 # Keep only the screenshots generated from the last failing test suite
 Capybara::Screenshot.prune_strategy = :keep_last_run


### PR DESCRIPTION
- Run cucumber in strict mode so it fails on undefined steps
- Add rubocop config file
- Make the javascript driver the default one
- Add no_javascript driver to Selenium
- Minor reformatting to make Ruby styles consistent
- Redefine some steps to support no JavaScript tests
- Print test report to /testreport