### PR TITLE
BAU: Use docker cp with docker ps -a to get testreports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN bundle install
 
 COPY features /features
 
-ENTRYPOINT ["bundle", "exec", "cucumber --strict"]
+ENTRYPOINT ["bundle", "exec", "cucumber", "--strict"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,7 @@ services:
   selenium-hub:
     image: selenium/standalone-firefox
 
-  verify-acceptance-tests:
+  test-runner:
     build: .
     depends_on:
       - selenium-hub
-    volumes:
-      - type: bind
-        source: ./testreport/
-        target: /testreport

--- a/run-tests-with-docker.sh
+++ b/run-tests-with-docker.sh
@@ -7,9 +7,8 @@ teardown() {
 
 trap teardown EXIT
 
-mkdir -p testreport
-docker-compose build verify-acceptance-tests
+docker-compose build
 docker-compose run \
-               -u $(id -u):$(id -g) \
                -e TEST_ENV=${TEST_ENV:-"joint"} \
-               verify-acceptance-tests -f pretty -f junit -o testreport/ $@
+               test-runner -f pretty -f junit -o testreport/ $@
+docker cp $(docker ps -a -q -f name="test-runner"):/testreport .


### PR DESCRIPTION
- docker ps has an -a flag that allows us to find stopped containers
- we can docker cp out of the container even if it is stopped
- this means that the files are written by whatever calls docker cp
(in this case mostly jenkins)