### PR TITLE
BAU: Add assertion to pages on eidas go back test

### DIFF
--- a/features/eidas_user_journeys.feature
+++ b/features/eidas_user_journeys.feature
@@ -6,7 +6,8 @@ Feature: eIDAS user journeys
     Given the user is at Test RP
     And they start an eIDAS journey
     And they select eIDAS scheme "Stub IDP Demo"
-    And they go back to the country picker
+    Then they should be at IDP "Stub Country"
+    Given they go back to the country picker
     And they select eIDAS scheme "Stub IDP Demo"
     Then they should be at IDP "Stub Country"
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -81,6 +81,7 @@ end
 
 Given('they go back to the country picker') do
   visit(URI.join(env('frontend'), 'choose-a-country'))
+  assert_text('Use a digital identity from another European country')
 end
 
 Given('they login as {string}') do |username|


### PR DESCRIPTION
-The test in question has been breaking intermittently. We are adding an extra check to ensure that the page has succesfully loaded before continuing onto the next step. This should hopefully prevent cucumber checking the wrong page and failing the test.