### PR TITLE
BAU: Bump docker compose version to allow injection of network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.4'
 
 services:
   selenium-hub:


### PR DESCRIPTION
- verify-local-startup needs to be able to start these tests
inside its network
- docker-compose >= 3.4 allows the providing of a .overrides.yml
file to add extra sections to docker-compose.yml
- To allow this to work, we need to bump the version in the local
docker-compose