### PR TITLE
 Port over remaining tests from ida-hub-acceptance-tests

### DIFF
--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -11,7 +11,7 @@ Feature: User account creation
     And they have all their documents
     And they do not have a phone
     And they continue to register with IDP "Stub Idp Demo"
-    And they enter user details:
+    And they submit user details:
       | firstname       | Jane       |
       | surname         | Doe        |
       | addressLine1    | 123        |
@@ -19,6 +19,7 @@ Feature: User account creation
       | addressTown     | Marlbury   |
       | addressPostCode | ABC 123    |
       | dateOfBirth     | 1987-03-03 |
+    When they give their consent
     And they submit cycle 3 "AA123456A"
     Then a user should have been created with details:
       | firstname   | Jane       |
@@ -38,6 +39,7 @@ Feature: User account creation
       | surname     | Bauer      |
       | dateofbirth | 1984-02-29 |
 
+
   Scenario: Registration without cycle 3
     Given the user is at Test RP
     And we set the RP name to "test-rp-noc3"
@@ -48,7 +50,7 @@ Feature: User account creation
     And they have all their documents
     And they do not have a phone
     And they continue to register with IDP "Stub Idp Demo"
-    And they enter user details:
+    And they submit user details:
       | firstname       | Jane       |
       | surname         | Doe        |
       | addressLine1    | 123        |
@@ -56,6 +58,7 @@ Feature: User account creation
       | addressTown     | Marlbury   |
       | addressPostCode | ABC 123    |
       | dateOfBirth     | 1987-03-03 |
+    When they give their consent
     Then a user should have been created with details:
       | firstname   | Jane       |
       | surname     | Doe        |

--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -5,10 +5,12 @@ Feature: User account creation
   Scenario: Registration and cycle 3
     Given the user is at Test RP
     And we do not want to match the user
-    And they start a registration journey
+    And they start a journey
+    And this is their first time using Verify
+    And they are above the age threshold
     And they have all their documents
     And they do not have a phone
-    And they register with "Stub Idp Demo"
+    And they continue to register with IDP "Stub Idp Demo"
     And they enter user details:
       | firstname       | Jane       |
       | surname         | Doe        |
@@ -36,15 +38,16 @@ Feature: User account creation
       | surname     | Bauer      |
       | dateofbirth | 1984-02-29 |
 
-
   Scenario: Registration without cycle 3
     Given the user is at Test RP
     And we set the RP name to "test-rp-noc3"
     And we do not want to match the user
-    And they start a registration journey
+    And they start a journey
+    And this is their first time using Verify
+    And they are above the age threshold
     And they have all their documents
     And they do not have a phone
-    And they register with "Stub Idp Demo"
+    And they continue to register with IDP "Stub Idp Demo"
     And they enter user details:
       | firstname       | Jane       |
       | surname         | Doe        |

--- a/features/authn_failure.feature
+++ b/features/authn_failure.feature
@@ -1,0 +1,47 @@
+Feature: User authentication failure
+
+  This tests authentication failure flows
+
+  Scenario: IDP returns authn failure when user attempts to register
+    Given the user is at Test RP
+    When they start a journey
+    And this is their first time using Verify
+    And they are below the age threshold
+    And they choose try to verify
+    Then they should arrive at the Select documents page
+
+    When they have all their documents
+    And they have a smart phone
+    And they continue to register with IDP "Post Office Stub"
+    When the IDP returns an Authn Failure response
+    Then they should arrive at the Failed registration page
+
+    When they choose to verify with another certified company
+    And they select the link find another company to verify you
+    Then they should arrive at the Select documents page
+
+
+  Scenario: IDP returns authn failure when user Signs in
+    Given the user is at Test RP
+    When they start a sign in journey
+    And they select IDP "Post Office Stub"
+    Then they should be at IDP "Post Office Stub"
+
+    When they fail sign in with idp
+    Then they should arrive at the Failed sign in page
+
+    When they choose to start again with another IDP
+    Then they should arrive at the Start page
+
+
+  Scenario: IDP returns authn failure requester error when user Signs in
+    Given the user is at Test RP
+    When they start a sign in journey
+    And they select IDP "Post Office Stub"
+    Then they should be at IDP "Post Office Stub"
+
+    When the IDP returns a Requester Error response
+    Then they should arrive at the Failed sign in page
+
+    When they choose to start again with another IDP
+    Then they should arrive at the Start page

--- a/features/back_button.feature
+++ b/features/back_button.feature
@@ -1,0 +1,29 @@
+Feature: User Back button
+
+  This tests back button flows
+
+  Scenario: User selects an IDP and then goes back to select another
+    Given the user is at Test RP
+    When they start a sign in journey
+    And they select IDP "Post Office Stub"
+    Then they should be at IDP "Post Office Stub"
+
+    When they choose to go back to the "sign-in" page
+    And they select IDP "Stub Idp Demo"
+    Then they should be at IDP "Stub Idp Demo"
+
+
+  Scenario: User selects sign in then goes back to select registration
+    Given the user is at Test RP
+    When they start a sign in journey
+    And they select IDP "Post Office Stub"
+    Then they should be at IDP "Post Office Stub"
+
+    When they choose to go back to the "sign-in" page
+    Then they should arrive at the Sign in page
+
+    When they choose to go back to the "start" page
+    Then they should arrive at the Start page
+
+    When they choose a registration journey
+    Then they should arrive at the Select documents page

--- a/features/cancel_refuse.feature
+++ b/features/cancel_refuse.feature
@@ -1,0 +1,10 @@
+Feature: User cancel or refuse
+
+  This tests user cancellation or refuse flows.
+
+  Scenario: User cancels at Idp login
+    Given the user is at Test RP
+    When they start a sign in journey
+    And they select IDP "Stub Idp Demo"
+    And they want to cancel sign in
+    Then they should arrive at the Start page

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -1,0 +1,14 @@
+Feature: User submit feedback
+
+  This tests user feedback submission with no session cookie.
+
+  Scenario: User successfully submits feedback with no valid session
+    Given the user is at Test RP
+    And they start a sign in journey but their session times out
+    And they go back to the start page
+    Then they are shown the cookies missing page
+    When they go to the feedback form
+    And they enter some feedback and submit the form
+    Then they receive confirmation that feedback was sent
+
+

--- a/features/journey_hint.feature
+++ b/features/journey_hint.feature
@@ -27,7 +27,7 @@ Scenario: Journey hint Registration
     And we set the RP name to "test-rp-non-eidas"
     And they select journey hint "Sign-in with eIDAS"
     And they start a journey
-    Then they arrive at the Start page
+    Then they should arrive at the Start page
 
   Scenario: Journey hint Non-repudiation
     Given the user is at Test RP
@@ -50,5 +50,5 @@ Scenario: Journey hint Registration
     And we set the RP name to "test-rp-non-eidas"
     And they select journey hint "Unspecified"
     And they start a journey
-    Then they arrive at the Start page
+    Then they should arrive at the Start page
 

--- a/features/journey_picker.feature
+++ b/features/journey_picker.feature
@@ -1,4 +1,4 @@
-Feature: Page to pick between Verify and eIDAS journies
+Feature: Page to pick between Verify and eIDAS journeys
 
   Test that a page appears to allow the user to select between
   Verify and eIDAS when there is no journey hint supplied and
@@ -9,7 +9,7 @@ Feature: Page to pick between Verify and eIDAS journies
     Given the user is at Test RP
     When they start a journey
     And they choose to use Verify
-    Then they arrive at the Start page
+    Then they should arrive at the Start page
 
 
   Scenario: eIDAS button on picker page goes to country picker
@@ -23,4 +23,4 @@ Feature: Page to pick between Verify and eIDAS journies
     Given the user is at Test RP
     And we set the RP name to "test-rp-non-eidas"
     When they start a journey
-    Then they arrive at the Start page
+    Then they should arrive at the Start page

--- a/features/loa1.feature
+++ b/features/loa1.feature
@@ -1,0 +1,30 @@
+Feature: User loa1
+
+  This tests user loa1 flows.
+
+  Scenario: Registration successful with IDP
+    Given the user is at Test RP
+    And we set the RP name to "loa1-test-rp"
+    When they start a journey
+    And they choose an loa1 registration journey
+    And they register for an LOA1 profile with IDP "Digidentity"
+    When they submit loa1 user details:
+      | firstname       | Jessica    |
+      | surname         | Rabbit     |
+      | addressLine1    | 1 Two St   |
+      | addressLine2    | Wells      |
+      | addressTown     | newtown    |
+      | addressPostCode | 1A 2BC     |
+      | dateOfBirth     | 1960-03-23 |
+    Then our Consent page should include LEVEL_1
+    When they give their consent
+    Then they should be successfully verified
+
+
+  Scenario: Sign in successful with IDP
+    Given the user is at Test RP
+    And we set the RP name to "loa1-test-rp"
+    When they start a sign in journey
+    And they select IDP "Digidentity"
+    And they login as "digidentity-loa1"
+    Then they should be successfully verified

--- a/features/loa1.feature
+++ b/features/loa1.feature
@@ -16,7 +16,7 @@ Feature: User loa1
       | addressTown     | newtown    |
       | addressPostCode | 1A 2BC     |
       | dateOfBirth     | 1960-03-23 |
-    Then our Consent page should include LEVEL_1
+    Then our Consent page should show "Level of assurance" = "LEVEL_1"
     When they give their consent
     Then they should be successfully verified
 

--- a/features/non_repudiation.feature
+++ b/features/non_repudiation.feature
@@ -1,0 +1,28 @@
+Feature: User registers, returns to confirm identity and signs in successfully
+
+  This tests user non-repudiation flow.
+
+  Scenario: User registers, confirms identity and signs in
+    Given the user is at Test RP
+    And they start a journey
+    And this is their first time using Verify
+    And they are above the age threshold
+    And they have all their documents
+    And they have a smart phone
+    And they continue to register with IDP "Experian"
+    And they submit user details:
+          | firstname       | Jane       |
+          | surname         | Doe        |
+          | addressLine1    | 123        |
+          | addressLine2    | Test Drive |
+          | addressTown     | Marlbury   |
+          | addressPostCode | ABC 123    |
+          | dateOfBirth     | 1987-03-03 |
+    Then our Consent page should show "Level of assurance" = "LEVEL_2"
+    When they give their consent
+    Then they should be successfully verified
+    When they click "Confirm Identity"
+    Then they arrive at the confirm identity page for "Experian"
+    When they click "Sign in with Experian"
+    And they login as the newly registered user
+    Then they should be successfully verified

--- a/features/simple.feature
+++ b/features/simple.feature
@@ -1,0 +1,32 @@
+Feature: User simple flows - sign in and registeration
+
+  This tests user simple flows.
+
+  Scenario: Sign in successful with IDP and cycle 3
+    Given the user is at Test RP
+    And they start a sign in journey
+    And they select IDP "Experian"
+    And they login as "experian-c3"
+    And they submit cycle 3 "AA123456A"
+    Then they should be successfully verified
+
+
+  Scenario: User registers with no documents
+    Given the user is at Test RP
+    And they start a journey
+    And this is their first time using Verify
+    And they are above the age threshold
+    And they do not have their documents
+    And they do not have other identity documents
+    And they have a smart phone
+    And they continue to register with IDP "Experian"
+    And they submit user details:
+      | firstname       | Jane       |
+      | surname         | Doe        |
+      | addressLine1    | 123        |
+      | addressLine2    | Test Drive |
+      | addressTown     | Marlbury   |
+      | addressPostCode | ABC 123    |
+      | dateOfBirth     | 1987-03-03 |
+    When they give their consent
+    Then they should be successfully verified

--- a/features/step_definitions/environments.yml
+++ b/features/step_definitions/environments.yml
@@ -3,15 +3,21 @@ local:
   test-rp: http://localhost:50130/test-rp
   idps:
     Stub Country: http://localhost:50140/eidas/stub-country/login
+    Stub Idp Demo: http://localhost:50140/stub-idp-demo/login
+    Post Office Stub: http://localhost:50140/post-office-test-rp/login
 
 docker-local:
   frontend: http://frontend
   test-rp: http://test-rp/test-rp
   idps:
     Stub Country: http://stub-idp/eidas/stub-country/login
+    Stub Idp Demo: http://stub-idp/stub-idp-demo/login
+    Post Office Stub: http://stub-idp/post-office-test-rp/login
 
 joint:
   frontend: https://www.joint.signin.service.gov.uk
   test-rp: https://test-rp-stub-joint.ida.digital.cabinet-office.gov.uk/test-rp
   idps:
     Stub Country: https://ida-stub-idp-joint.cloudapps.digital/eidas/stub-country/login
+    Stub Idp Demo: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo/login
+    Post Office Stub: https://ida-stub-idp-joint.cloudapps.digital/post-office-test-rp/login

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -202,6 +202,10 @@ Given('they choose to go back to the {string} page') do |page|
   assert_text(page_text)
 end
 
+Given('they want to cancel sign in') do
+  click_on('Cancel')
+end
+
 Given('they enter user details:') do |details|
   details.rows_hash.each do |input, value|
     fill_in(input, with: value)

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -13,6 +13,17 @@ def see_journey_picker?
   @see_journey_picker
 end
 
+def page_heading_text(page)
+  case page
+    when 'select-documents' then
+      'Your photo identity document'
+    when 'start' then
+      'Sign in with GOV.UK Verify'
+    when 'start' then
+      'Who do you have an identity account with?'
+  end
+end
+
 Given('the user is at Test RP') do
   visit(env('test-rp'))
   @see_journey_picker = true
@@ -46,10 +57,17 @@ Given('they start a sign in journey') do
   click_on('Continue')
 end
 
-Given('they start a registration journey') do
-  click_on('Start')
-
+Given('this is their first time using Verify') do
   click_on('Use GOV.UK Verify') if see_journey_picker?
+  choose('start_form_selection_true')
+  click_on('Continue')
+  click_on('Next')
+  click_on('Next')
+  click_on('Start now')
+  click_on('Continue')
+end
+
+Given('they choose a registration journey') do
   choose('start_form_selection_true')
   click_on('Continue')
   click_on('Next')
@@ -58,6 +76,18 @@ Given('they start a registration journey') do
   click_on('Continue')
 
   choose('will_it_work_for_me_form_above_age_threshold_true')
+  choose('will_it_work_for_me_form_resident_last_12_months_true')
+  click_on('Continue')
+end
+
+And('they are above the age threshold') do
+  choose('will_it_work_for_me_form_above_age_threshold_true')
+  choose('will_it_work_for_me_form_resident_last_12_months_true')
+  click_on('Continue')
+end
+
+And('they are below the age threshold') do
+  choose('will_it_work_for_me_form_above_age_threshold_false')
   choose('will_it_work_for_me_form_resident_last_12_months_true')
   click_on('Continue')
 end
@@ -127,13 +157,49 @@ Given('they do not have a phone') do
   click_on('Continue')
 end
 
-Given('they register with {string}') do |idp|
+Given('they continue to register with IDP {string}') do |idp|
   click_on("Choose #{idp}")
   click_on("Continue to the #{idp} website")
 end
 
 Given('they select IDP {string}') do |idp|
   click_on("Select #{idp}", match: :first)
+end
+
+Given('the IDP returns an Authn Failure response') do
+  click_on('tab-login')
+  click_on('Authn Failure')
+end
+
+Given('the IDP returns a Requester Error response') do
+  click_on('Submit Requester Error')
+end
+
+Given('they fail sign in with idp') do
+  click_on('Authn Failure')
+end
+
+Given('they choose try to verify') do
+  click_link('verify-identity-online')
+end
+
+Given('they choose to verify with another certified company') do
+  find('span.summary', text: 'Try verifying with another certified company').click
+end
+
+Given('they select the link find another company to verify you') do
+  click_link('Find another company to verify you')
+end
+
+Given('they choose to start again with another IDP') do
+  click_on('startAgain')
+end
+
+Given('they choose to go back to the {string} page') do |page|
+  visit(URI.join(env('frontend'), page))
+
+  page_text = page_heading_text(page)
+  assert_text(page_text)
 end
 
 Given('they enter user details:') do |details|
@@ -158,7 +224,6 @@ Given('they enter eidas user details:') do |details|
   fill_in('password', with: 'bar')
   click_on('Register')
   click_on('I Agree')
-
 end
 
 Then('they should be at IDP {string}') do |idp|
@@ -183,7 +248,7 @@ Then('user account creation should fail') do
   assert_text('Sorry, something went wrong')
 end
 
-Then('they arrive at the Start page') do
+Then('they should arrive at the Start page') do
   assert_text('Sign in with GOV.UK Verify')
 end
 
@@ -211,4 +276,20 @@ end
 
 Then('they logout') do
   click_on('Logout')
+end
+
+Then('they should arrive at the Select documents page') do
+  assert_text('Your photo identity document')
+end
+
+Then('they should arrive at the Sign in page') do
+  assert_text('Who do you have an identity account with?')
+end
+
+Then('they should arrive at the Failed registration page') do
+  assert_text('was unable to verify your identity')
+end
+
+Then('they should arrive at the Failed sign in page') do
+  assert_text('You may have selected the wrong company')
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -15,12 +15,12 @@ end
 
 def page_heading_text(page)
   case page
-    when 'select-documents' then
-      'Your photo identity document'
-    when 'start' then
-      'Sign in with GOV.UK Verify'
-    when 'start' then
-      'Who do you have an identity account with?'
+  when 'select-documents' then
+    'Your photo identity document'
+  when 'start' then
+    'Sign in with GOV.UK Verify'
+  when 'start' then
+    'Who do you have an identity account with?'
   end
 end
 
@@ -78,6 +78,14 @@ Given('they choose a registration journey') do
   choose('will_it_work_for_me_form_above_age_threshold_true')
   choose('will_it_work_for_me_form_resident_last_12_months_true')
   click_on('Continue')
+end
+
+Given('they choose an loa1 registration journey') do
+  choose('start_form_selection_true')
+  click_on('Continue')
+  click_on('Next')
+  click_on('Next')
+  click_on('Start now')
 end
 
 And('they are above the age threshold') do
@@ -162,6 +170,12 @@ Given('they continue to register with IDP {string}') do |idp|
   click_on("Continue to the #{idp} website")
 end
 
+Given('they register for an LOA1 profile with IDP {string}') do |idp|
+  click_on("Choose #{idp}")
+  assert_text('Create your ' + idp + ' identity account')
+  click_on("Continue to the #{idp} website")
+end
+
 Given('they select IDP {string}') do |idp|
   click_on("Select #{idp}", match: :first)
 end
@@ -214,6 +228,24 @@ Given('they enter user details:') do |details|
   fill_in('username', with: SecureRandom.hex)
   fill_in('password', with: 'bar')
   click_on('Register')
+  click_on('I Agree')
+
+  click_on('Continue')
+end
+
+Given('they submit loa1 user details:') do |details|
+  details.rows_hash.each do |input, value|
+    fill_in(input, with: value)
+  end
+
+  fill_in('username', with: SecureRandom.hex)
+  fill_in('password', with: 'bar')
+  select('Level 1', from: 'loa')
+
+  click_on('Register')
+end
+
+Given('they give their consent') do
   click_on('I Agree')
 
   click_on('Continue')
@@ -296,4 +328,9 @@ end
 
 Then('they should arrive at the Failed sign in page') do
   assert_text('You may have selected the wrong company')
+end
+
+Then('our Consent page should include LEVEL_1') do
+  assert_text("You've successfully authenticated")
+  assert_text('LEVEL_1')
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -57,6 +57,11 @@ Given('they start a sign in journey') do
   click_on('Continue')
 end
 
+Given('they start a sign in journey but their session times out') do
+  step('they start a sign in journey')
+  Capybara.reset_sessions!
+end
+
 Given('this is their first time using Verify') do
   click_on('Use GOV.UK Verify') if see_journey_picker?
   choose('start_form_selection_true')
@@ -133,6 +138,13 @@ Given('they login as {string}') do |username|
   click_on('I Agree')
 end
 
+Given('they login as the newly registered user') do
+  fill_in('username', with: @username)
+  fill_in('password', with: 'bar')
+  click_on('SignIn')
+  click_on('I Agree')
+end
+
 Given('they login as {string} with a random pid') do |username|
   fill_in('username', with: username)
   fill_in('password', with: 'bar')
@@ -154,6 +166,17 @@ Given('they have all their documents') do
   click_on('Continue')
 end
 
+Given('they do not have their documents') do
+  choose('select_documents_form_any_driving_licence_false')
+  choose('select_documents_form_passport_false')
+  click_on('Continue')
+end
+
+Given('they do not have other identity documents') do
+  choose('other_identity_documents_form_non_uk_id_document_false')
+  click_on('Continue')
+end
+
 Given('they have a smart phone') do
   choose('select_phone_form_mobile_phone_true')
   choose('select_phone_form_smart_phone_true')
@@ -168,12 +191,14 @@ end
 Given('they continue to register with IDP {string}') do |idp|
   click_on("Choose #{idp}")
   click_on("Continue to the #{idp} website")
+  @idp = "#{idp}"
 end
 
 Given('they register for an LOA1 profile with IDP {string}') do |idp|
   click_on("Choose #{idp}")
   assert_text('Create your ' + idp + ' identity account')
   click_on("Continue to the #{idp} website")
+  @idp = "#{idp}"
 end
 
 Given('they select IDP {string}') do |idp|
@@ -220,34 +245,27 @@ Given('they want to cancel sign in') do
   click_on('Cancel')
 end
 
-Given('they enter user details:') do |details|
+Given /they submit (loa1 |)user details:$/ do |assurance_level, details|
+
   details.rows_hash.each do |input, value|
     fill_in(input, with: value)
+
+    if input == 'firstname'
+            @username = value + SecureRandom.hex
+    end
   end
 
-  fill_in('username', with: SecureRandom.hex)
+  fill_in('username', with: @username)
   fill_in('password', with: 'bar')
-  click_on('Register')
-  click_on('I Agree')
 
-  click_on('Continue')
-end
-
-Given('they submit loa1 user details:') do |details|
-  details.rows_hash.each do |input, value|
-    fill_in(input, with: value)
+  if assurance_level == 'loa1 '
+    select('Level 1', from: 'loa')
   end
-
-  fill_in('username', with: SecureRandom.hex)
-  fill_in('password', with: 'bar')
-  select('Level 1', from: 'loa')
-
   click_on('Register')
 end
 
 Given('they give their consent') do
   click_on('I Agree')
-
   click_on('Continue')
 end
 
@@ -330,7 +348,42 @@ Then('they should arrive at the Failed sign in page') do
   assert_text('You may have selected the wrong company')
 end
 
-Then('our Consent page should include LEVEL_1') do
-  assert_text("You've successfully authenticated")
-  assert_text('LEVEL_1')
+Then('our Consent page should show "Level of assurance" = {string}') do |assurance_level|
+
+  assert_text("You've successfully authenticated with #{@idp}")
+  assert_text("#{assurance_level}")
+end
+
+Then ('they are shown the cookies missing page') do
+  assert_text('GOV.UK Verify can only be accessed from a government service.')
+  assert_text("If you can’t access GOV.UK Verify from a service, enable your cookies.")
+end
+
+When('they go to the feedback form') do
+  page.find(:xpath, "//a[contains(text(),'feedback form')]").click
+end
+
+And('they enter some feedback and submit the form') do
+  fill_in('feedback_form_what', with: 'Acceptance testing')
+  fill_in('feedback_form_details', with: 'Feedback form testing')
+  choose('feedback_form_reply_true')
+  fill_in('feedback_form_name', with: 'Acc Test')
+  fill_in('feedback_form_email', with: 'acctest@example.com')
+  click_on('Send message')
+end
+
+Then('they receive confirmation that feedback was sent') do
+  assert_text('Thank you for your feedback')
+end
+
+And('they go back to the start page') do
+  visit(URI.join(env('frontend'), 'start'))
+end
+
+When('they click {string}') do |value|
+  if value == ('Sign in with '+@idp)
+    page.find(:xpath, "//button[contains(text(), '#{value}')]").click
+  else
+    page.find(:xpath, "//input[@value= '#{value}']").click
+  end
 end


### PR DESCRIPTION
Created the following new feature files:
feedback.feature
non_repudiation.feature
simple.feature

Made changes to existing tests to account for some code refactoring:
account_creation.feature
loa1.feature

Refactored step_definitions and added the following new steps:
Given('they start a sign in journey but their session times out') do
Given('they login as the newly registered user') do
Given('they do not have their documents') do
Given('they do not have other identity documents') do
Then ('they are shown the cookies missing page') do
When('they go to the feedback form') do
And('they enter some feedback and submit the form') do
Then('they receive confirmation that feedback was sent') do
And('they go back to the start page') do
When('they click {string}') do |value|

NOTE:
Includes commits by cobainc0