### PR TITLE
EID-815 Sanitise existing tests by replacing references to live IDP's

### DIFF
--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -10,7 +10,7 @@ Feature: User account creation
     And they are above the age threshold
     And they have all their documents
     And they do not have a phone
-    And they continue to register with IDP "Stub Idp Demo"
+    And they continue to register with IDP "Stub Idp Demo One"
     And they submit user details:
       | firstname       | Jane       |
       | surname         | Doe        |
@@ -31,8 +31,8 @@ Feature: User account creation
     Given the user is at Test RP
     And we do not want to match the user
     And they start a sign in journey
-    And they select IDP "Stub Idp Demo"
-    And they login as "stub-idp-demo"
+    And they select IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one"
     And they submit cycle 3 "AA123456A"
     Then a user should have been created with details:
       | firstname   | Jack       |
@@ -49,7 +49,7 @@ Feature: User account creation
     And they are above the age threshold
     And they have all their documents
     And they do not have a phone
-    And they continue to register with IDP "Stub Idp Demo"
+    And they continue to register with IDP "Stub Idp Demo One"
     And they submit user details:
       | firstname       | Jane       |
       | surname         | Doe        |
@@ -70,8 +70,8 @@ Feature: User account creation
     And we set the RP name to "test-rp-noc3"
     And we do not want to match the user
     And they start a sign in journey
-    And they select IDP "Stub Idp Demo"
-    And they login as "stub-idp-demo"
+    And they select IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one"
     Then a user should have been created with details:
       | firstname   | Jack       |
       | surname     | Bauer      |
@@ -84,6 +84,6 @@ Feature: User account creation
     And we do not want to match the user
     And we want to fail account creation
     And they start a sign in journey
-    And they select IDP "Stub Idp Demo"
-    And they login as "stub-idp-demo" with a random pid
+    And they select IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one" with a random pid
     Then user account creation should fail

--- a/features/authn_failure.feature
+++ b/features/authn_failure.feature
@@ -12,7 +12,7 @@ Feature: User authentication failure
 
     When they have all their documents
     And they have a smart phone
-    And they continue to register with IDP "Post Office Stub"
+    And they continue to register with IDP "Stub Idp Demo Two"
     When the IDP returns an Authn Failure response
     Then they should arrive at the Failed registration page
 
@@ -24,8 +24,8 @@ Feature: User authentication failure
   Scenario: IDP returns authn failure when user Signs in
     Given the user is at Test RP
     When they start a sign in journey
-    And they select IDP "Post Office Stub"
-    Then they should be at IDP "Post Office Stub"
+    And they select IDP "Stub Idp Demo Two"
+    Then they should be at IDP "Stub Idp Demo Two"
 
     When they fail sign in with idp
     Then they should arrive at the Failed sign in page
@@ -37,8 +37,8 @@ Feature: User authentication failure
   Scenario: IDP returns authn failure requester error when user Signs in
     Given the user is at Test RP
     When they start a sign in journey
-    And they select IDP "Post Office Stub"
-    Then they should be at IDP "Post Office Stub"
+    And they select IDP "Stub Idp Demo Two"
+    Then they should be at IDP "Stub Idp Demo Two"
 
     When the IDP returns a Requester Error response
     Then they should arrive at the Failed sign in page

--- a/features/back_button.feature
+++ b/features/back_button.feature
@@ -5,19 +5,19 @@ Feature: User Back button
   Scenario: User selects an IDP and then goes back to select another
     Given the user is at Test RP
     When they start a sign in journey
-    And they select IDP "Post Office Stub"
-    Then they should be at IDP "Post Office Stub"
+    And they select IDP "Stub Idp Demo Two"
+    Then they should be at IDP "Stub Idp Demo Two"
 
     When they choose to go back to the "sign-in" page
-    And they select IDP "Stub Idp Demo"
-    Then they should be at IDP "Stub Idp Demo"
+    And they select IDP "Stub Idp Demo One"
+    Then they should be at IDP "Stub Idp Demo One"
 
 
   Scenario: User selects sign in then goes back to select registration
     Given the user is at Test RP
     When they start a sign in journey
-    And they select IDP "Post Office Stub"
-    Then they should be at IDP "Post Office Stub"
+    And they select IDP "Stub Idp Demo Two"
+    Then they should be at IDP "Stub Idp Demo Two"
 
     When they choose to go back to the "sign-in" page
     Then they should arrive at the Sign in page

--- a/features/cancel_refuse.feature
+++ b/features/cancel_refuse.feature
@@ -5,6 +5,6 @@ Feature: User cancel or refuse
   Scenario: User cancels at Idp login
     Given the user is at Test RP
     When they start a sign in journey
-    And they select IDP "Stub Idp Demo"
+    And they select IDP "Stub Idp Demo One"
     And they want to cancel sign in
     Then they should arrive at the Start page

--- a/features/journey_hint.feature
+++ b/features/journey_hint.feature
@@ -33,12 +33,12 @@ Scenario: Journey hint Registration
   Scenario: Journey hint Non-repudiation
     Given the user is at Test RP
     And they start a sign in journey
-    And they select IDP "Stub Idp Demo"
-    And they login as "stub-idp-demo"
+    And they select IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one"
     And they logout
     And they select journey hint "Non-repudiation"
     And they start a journey
-    Then they arrive at the confirm identity page for "Stub Idp Demo"
+    Then they arrive at the confirm identity page for "Stub Idp Demo One"
 
   Scenario: Journey hint Unspecified
     Given the user is at Test RP

--- a/features/loa1.feature
+++ b/features/loa1.feature
@@ -7,7 +7,7 @@ Feature: User loa1
     And we set the RP name to "loa1-test-rp"
     When they start a journey
     And they choose an loa1 registration journey
-    And they register for an LOA1 profile with IDP "Digidentity"
+    And they register for an LOA1 profile with IDP "Stub Idp Demo One"
     When they submit loa1 user details:
       | firstname       | Jessica    |
       | surname         | Rabbit     |
@@ -25,6 +25,6 @@ Feature: User loa1
     Given the user is at Test RP
     And we set the RP name to "loa1-test-rp"
     When they start a sign in journey
-    And they select IDP "Digidentity"
-    And they login as "digidentity-loa1"
+    And they select IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one-loa1"
     Then they should be successfully verified

--- a/features/non_repudiation.feature
+++ b/features/non_repudiation.feature
@@ -9,7 +9,7 @@ Feature: User registers, returns to confirm identity and signs in successfully
     And they are above the age threshold
     And they have all their documents
     And they have a smart phone
-    And they continue to register with IDP "Experian"
+    And they continue to register with IDP "Stub Idp Demo Two"
     And they submit user details:
           | firstname       | Jane       |
           | surname         | Doe        |
@@ -22,7 +22,7 @@ Feature: User registers, returns to confirm identity and signs in successfully
     When they give their consent
     Then they should be successfully verified
     When they click "Confirm Identity"
-    Then they arrive at the confirm identity page for "Experian"
-    When they click "Sign in with Experian"
+    Then they arrive at the confirm identity page for "Stub Idp Demo Two"
+    When they click "Sign in with Stub Idp Demo Two"
     And they login as the newly registered user
     Then they should be successfully verified

--- a/features/simple.feature
+++ b/features/simple.feature
@@ -5,8 +5,8 @@ Feature: User simple flows - sign in and registeration
   Scenario: Sign in successful with IDP and cycle 3
     Given the user is at Test RP
     And they start a sign in journey
-    And they select IDP "Experian"
-    And they login as "experian-c3"
+    And they select IDP "Stub Idp Demo Two"
+    And they login as "stub-idp-demo-two-c3"
     And they submit cycle 3 "AA123456A"
     Then they should be successfully verified
 
@@ -19,7 +19,7 @@ Feature: User simple flows - sign in and registeration
     And they do not have their documents
     And they do not have other identity documents
     And they have a smart phone
-    And they continue to register with IDP "Experian"
+    And they continue to register with IDP "Stub Idp Demo Two"
     And they submit user details:
       | firstname       | Jane       |
       | surname         | Doe        |

--- a/features/step_definitions/environments.yml
+++ b/features/step_definitions/environments.yml
@@ -4,7 +4,8 @@ local:
   idps:
     Stub Country: http://localhost:50140/eidas/stub-country/login
     Stub Idp Demo: http://localhost:50140/stub-idp-demo/login
-    Post Office Stub: http://localhost:50140/post-office-test-rp/login
+    Stub Idp Demo One: http://localhost:50140/stub-idp-demo-one/login
+    Stub Idp Demo Two: http://localhost:50140/stub-idp-demo-two/login
 
 docker-local:
   frontend: http://frontend
@@ -12,7 +13,6 @@ docker-local:
   idps:
     Stub Country: http://stub-idp/eidas/stub-country/login
     Stub Idp Demo: http://stub-idp/stub-idp-demo/login
-    Post Office Stub: http://stub-idp/post-office-test-rp/login
 
 joint:
   frontend: https://www.joint.signin.service.gov.uk
@@ -20,11 +20,13 @@ joint:
   idps:
     Stub Country: https://ida-stub-idp-joint.cloudapps.digital/eidas/stub-country/login
     Stub Idp Demo: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo/login
-    Post Office Stub: https://ida-stub-idp-joint.cloudapps.digital/post-office-test-rp/login
+    Stub Idp Demo One: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-one/login
+    Stub Idp Demo Two: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-two/login
 
 staging:
   frontend: https://www.staging.signin.service.gov.uk
   test-rp: https://test-rp-stub-staging.ida.digital.cabinet-office.gov.uk/test-rp
   idps:
     Stub Idp Demo: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo/login
-    Post Office Stub: https://ida-stub-idp-staging.cloudapps.digital/post-office-test-rp/login
+    Stub Idp Demo One: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/login
+    Stub Idp Demo Two: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-two/login


### PR DESCRIPTION
Add the following environment appropriate lines to environments.yml for local, staging and joint.
Stub Idp Demo One: http://localhost:50140/stub-idp-demo-one/login
Stub Idp Demo Two: http://localhost:50140/stub-idp-demo-two/login
Stub Idp Demo One: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/login
Stub Idp Demo Two: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-two/login
Stub Idp Demo One: http://localhost:50140/stub-idp-demo-one/login
Stub Idp Demo Two: http://localhost:50140/stub-idp-demo-two/login

Removed entries referencing post-office-stub from environments.yml
Removed references to live IDP's from existing tests and replaced them with Stub Idp Demo One or Stub Idp Demo Two.