### PR TITLE
[DO NOT MERGE] EID-795: Refine error pages

### DIFF
--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -86,4 +86,20 @@ Feature: User account creation
     And they start a sign in journey
     And they select IDP "Stub Idp Demo"
     And they login as "stub-idp-demo" with a random pid
-    Then user account creation should fail
+    Then should arrive at the user account creation error page
+    When they click on link "Other ways to prove your identity online"
+    Then they should arrive at the Test RP start page with error notice
+
+  @Eidas
+  Scenario: Failed user account creation with an eIDAS journey
+    Given the user is at Test RP
+    And we do not want to match the user
+    And we want to fail account creation
+    And they start an eIDAS journey
+    And they select eIDAS scheme "Stub IDP Demo"
+    Then they should be at IDP "Stub Country"
+    And they login as "stub-country-new"
+    And they submit cycle 3 "AB123456C"
+    Then should arrive at the user account creation error page
+    When they click on link "Other ways to prove your identity online"
+    Then they should arrive at the prove identity page

--- a/features/journey_hint.feature
+++ b/features/journey_hint.feature
@@ -44,7 +44,7 @@ Scenario: Journey hint Registration
     Given the user is at Test RP
     And they select journey hint "Unspecified"
     And they start a journey
-    Then they arrive at the prove identity page
+    Then they should arrive at the prove identity page
 
   Scenario: Journey hint Unspecified when Eidas is Disabled
     Given the user is at Test RP
@@ -52,4 +52,3 @@ Scenario: Journey hint Registration
     And they select journey hint "Unspecified"
     And they start a journey
     Then they should arrive at the Start page
-

--- a/features/non_repudiation.feature
+++ b/features/non_repudiation.feature
@@ -21,8 +21,8 @@ Feature: User registers, returns to confirm identity and signs in successfully
     Then our Consent page should show "Level of assurance" = "LEVEL_2"
     When they give their consent
     Then they should be successfully verified
-    When they click "Confirm Identity"
+    When they click button "Confirm Identity"
     Then they arrive at the confirm identity page for "Experian"
-    When they click "Sign in with Experian"
+    When they click button "Sign in with Experian"
     And they login as the newly registered user
     Then they should be successfully verified

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -303,7 +303,14 @@ Then('a user should have been created with details:') do |details|
   end
 end
 
-Then('user account creation should fail') do
+Then('they should arrive at the Test RP start page with error notice') do
+  page = env('test-rp')
+  assert_current_path(page, ignore_query: true)
+  assert_text('Register for an identity profile')
+  assert_text('There has been a problem signing you in.')
+end
+
+Then('should arrive at the user account creation error page') do
   assert_text('Sorry, there is a problem with the service')
 end
 
@@ -324,7 +331,7 @@ Then('they arrive at the confirm identity page for {string}') do |idp|
   assert_text('Sign in with '+idp)
 end
 
-Then('they arrive at the prove identity page') do
+Then('they should arrive at the prove identity page') do
   assert_text('Prove your identity to continue')
   assert_text('Choose how you want to prove your identity so you can register for an identity profile.')
 end
@@ -385,10 +392,14 @@ And('they go back to the start page') do
   visit(URI.join(env('frontend'), 'start'))
 end
 
-When('they click {string}') do |value|
+When('they click button {string}') do |value|
   if value == ('Sign in with '+@idp)
     page.find(:xpath, "//button[contains(text(), '#{value}')]").click
   else
     page.find(:xpath, "//input[@value= '#{value}']").click
   end
+end
+
+When('they click on link {string}') do |value|
+  click_on(value)
 end


### PR DESCRIPTION
Added tests to check that the error pages on UAC failure redirect the users to either the service start page (for Verify journeys) or to the Verify/eIDAS picker (for eIDAS journeys)