### PR TITLE
Bau - Remove the match first check

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -207,7 +207,7 @@ Given('they register for an LOA1 profile with IDP {string}') do |idp|
 end
 
 Given('they select IDP {string}') do |idp|
-  click_on("Select #{idp}", match: :first)
+  click_on("Select #{idp}", match: :prefer_exact)
 end
 
 Given('the IDP returns an Authn Failure response') do


### PR DESCRIPTION
- Remove the unneccesary check to match the first IDP as it doesn't offer
any value and seems to cause a lot of problems when introducing stub-idp-demo-one
- When we introduce stub-idp-demo-one, the test fails as it matches this first
instead of what it is meant to be looking for being stub-idp-demo. Removing this
check allow it to match against stub-idp-demo which is the correct behaviour