### PR TITLE
EID-894 - Add acceptance test to check MSA can handle new signing algorithm

### DIFF
--- a/features/eidas_user_journeys.feature
+++ b/features/eidas_user_journeys.feature
@@ -79,3 +79,11 @@ Feature: eIDAS user journeys
       | firstname   | Jack       |
       | surname     | Bauer      |
       | dateofbirth | 1984-02-29 |
+
+  @Eidas
+  Scenario: User signs in with a country which responds with rsassa-pss signing algorithm
+    Given the user is at Test RP
+    And they start an eIDAS journey
+    And they select IDP "Stub IDP Demo"
+    And they login as "stub-country" with "rsassa-pss" signing algorithm
+    Then they should be successfully verified

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -392,3 +392,12 @@ When('they click {string}') do |value|
     page.find(:xpath, "//input[@value= '#{value}']").click
   end
 end
+
+Given('they login as {string} with {string} signing algorithm') do |username, algorithm|
+  fill_in('username', with: username)
+  fill_in('password', with: 'bar')
+  click_on('SignIn')
+  assert_text("You've successfully authenticated")
+  page.execute_script("document.getElementById('signingAlgorithm').value = '#{algorithm}';")
+  click_on('I Agree')
+end


### PR DESCRIPTION
- Changes to the MSA means that it can support extra signing algorithms to comply with the eidas spec. 
- Stub country will have the ability to sign assertions with 1 of 2 algorithms, rsassa-pss or rsasha256. By default it signs using the rsasha256 but this added test will allow to sign the stub country response with rsassa-pss without changing the UI to ensure the latest MSA can support this. 
- This is carried out by changing a hidden value within eidasConsent.ftl within verify-stub-idp 