### PR TITLE
BAU: Fail fast when running tests

### DIFF
--- a/run-tests-with-docker.sh
+++ b/run-tests-with-docker.sh
@@ -4,7 +4,7 @@ set -u
 docker-compose build
 docker-compose run \
                -e TEST_ENV=${TEST_ENV:-"joint"} \
-               test-runner -f pretty -f junit -o testreport/ "$@"
+               test-runner -f pretty -f junit -o testreport/ --fail-fast "$@"
 exit_status=$?
 docker cp $(docker ps -a -q -f name="test-runner"):/testreport .
 docker-compose down

--- a/run-tests-with-docker.sh
+++ b/run-tests-with-docker.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 set -u
 
+# Make sure that we tear down first due to tools deploy getting these
+# containers into an unrecoverable state if we don't explicitly do this
+docker-compose down
 docker-compose build
 docker-compose run \
                -e TEST_ENV=${TEST_ENV:-"joint"} \


### PR DESCRIPTION
- If any of the tests fail, the build fails
- Don't bother waiting, just fail straight away to reduce cycle time