### PR TITLE
EID-795: Add tests to check the Refined error pages work correctly

### DIFF
--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -22,10 +22,10 @@ Feature: User account creation
     When they give their consent
     And they submit cycle 3 "AA123456A"
     Then a user should have been created with details:
-      | firstname       | Jane           |
-      | surname         | Doe            |
-      | currentaddress  | 123 Test Drive |
-      | dateofbirth     | 1987-03-03     |
+      | firstname      | Jane           |
+      | surname        | Doe            |
+      | currentaddress | 123 Test Drive |
+      | dateofbirth    | 1987-03-03     |
 
   Scenario: Sign in and cycle 3
     Given the user is at Test RP
@@ -87,4 +87,38 @@ Feature: User account creation
     And they start a sign in journey
     And they select IDP "Stub Idp Demo One"
     And they login as "stub-idp-demo-one" with a random pid
-    Then user account creation should fail
+    Then should arrive at the user account creation error page
+    When they click on link "Other ways to prove your identity online"
+    Then they should arrive at the Test RP start page with error notice
+
+  @Eidas
+  Scenario: Failed user account creation with eIDAS and retried
+    Given the user is at Test RP
+    And we do not want to match the user
+    And we want to fail account creation
+    And they start an eIDAS journey
+    And they select eIDAS scheme "Stub IDP Demo"
+    Then they should be at IDP "Stub Country"
+    And they login as "stub-country-new"
+    And they submit cycle 3 "AB123456C"
+    Then should arrive at the user account creation error page
+    When they click on link "Other ways to prove your identity online"
+    Then they should arrive at the prove identity page
+    And they choose to use a European identity scheme
+    Then they should arrive at the country picker
+
+  @Eidas
+  Scenario: Failed user account creation with eIDAS and retried with Verify
+    Given the user is at Test RP
+    And we do not want to match the user
+    And we want to fail account creation
+    And they start an eIDAS journey
+    And they select eIDAS scheme "Stub IDP Demo"
+    Then they should be at IDP "Stub Country"
+    And they login as "stub-country-new"
+    And they submit cycle 3 "AB123456C"
+    Then should arrive at the user account creation error page
+    When they click on link "Other ways to prove your identity online"
+    Then they should arrive at the prove identity page
+    And they choose to use Verify
+    Then they should arrive at the Start page

--- a/features/authn_failure.feature
+++ b/features/authn_failure.feature
@@ -27,10 +27,38 @@ Feature: User authentication failure
     And they select IDP "Stub Idp Demo Two"
     Then they should be at IDP "Stub Idp Demo Two"
 
-    When they fail sign in with idp
+    When they fail sign in with IDP
     Then they should arrive at the Failed sign in page
 
     When they choose to start again with another IDP
+    Then they should arrive at the Start page
+
+
+  @Eidas
+  Scenario: Country returns AuthFailure on sign-in and user retries
+    Given the user is at Test RP
+    When they start an eIDAS journey
+    And they select eIDAS scheme "Stub IDP Demo"
+    Then they should be at IDP "Stub Country"
+    When they fail sign in with IDP
+    Then they should arrive at the Failed country sign in page
+    When they click on link "Other ways to prove your identity online"
+    Then they should arrive at the prove identity page
+    And they choose to use a European identity scheme
+    Then they should arrive at the country picker
+
+
+  @Eidas
+  Scenario: Country returns AuthFailure on sign-in and user retries with Verify
+    Given the user is at Test RP
+    When they start an eIDAS journey
+    And they select eIDAS scheme "Stub IDP Demo"
+    Then they should be at IDP "Stub Country"
+    When they fail sign in with IDP
+    Then they should arrive at the Failed country sign in page
+    When they click on link "Other ways to prove your identity online"
+    Then they should arrive at the prove identity page
+    And they choose to use Verify
     Then they should arrive at the Start page
 
 

--- a/features/journey_hint.feature
+++ b/features/journey_hint.feature
@@ -21,7 +21,7 @@ Scenario: Journey hint Registration
     Given the user is at Test RP
     And they select journey hint "Sign-in with eIDAS"
     And they start a journey
-    Then they arrive at the country picker
+    Then they should arrive at the country picker
 
   Scenario: Journey hint Sign-in with eIDAS when Eidas is Disabled
     Given the user is at Test RP
@@ -44,7 +44,7 @@ Scenario: Journey hint Registration
     Given the user is at Test RP
     And they select journey hint "Unspecified"
     And they start a journey
-    Then they arrive at the prove identity page
+    Then they should arrive at the prove identity page
 
   Scenario: Journey hint Unspecified when Eidas is Disabled
     Given the user is at Test RP
@@ -52,4 +52,3 @@ Scenario: Journey hint Registration
     And they select journey hint "Unspecified"
     And they start a journey
     Then they should arrive at the Start page
-

--- a/features/journey_picker.feature
+++ b/features/journey_picker.feature
@@ -17,7 +17,7 @@ Feature: Page to pick between Verify and eIDAS journeys
     Given the user is at Test RP
     When they start a journey
     And they choose to use a European identity scheme
-    Then they arrive at the country picker
+    Then they should arrive at the country picker
 
 
   Scenario: RP without eIDAS enabled doesn't trigger picker

--- a/features/non_repudiation.feature
+++ b/features/non_repudiation.feature
@@ -21,8 +21,8 @@ Feature: User registers, returns to confirm identity and signs in successfully
     Then our Consent page should show "Level of assurance" = "LEVEL_2"
     When they give their consent
     Then they should be successfully verified
-    When they click "Confirm Identity"
+    When they click button "Confirm Identity"
     Then they arrive at the confirm identity page for "Stub Idp Demo Two"
-    When they click "Sign in with Stub Idp Demo Two"
+    When they click button "Sign in with Stub Idp Demo Two"
     And they login as the newly registered user
     Then they should be successfully verified with level of assurance "LEVEL_2"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -219,7 +219,7 @@ Given('the IDP returns a Requester Error response') do
   click_on('Submit Requester Error')
 end
 
-Given('they fail sign in with idp') do
+Given('they fail sign in with IDP') do
   click_on('Authn Failure')
 end
 
@@ -317,17 +317,26 @@ Then('a user should have been created with details:') do |details|
   end
 end
 
-Then('user account creation should fail') do
+Then('they should arrive at the Test RP start page with error notice') do
+  page = env('test-rp')
+  assert_current_path(page, ignore_query: true)
+  assert_text('Register for an identity profile')
+  assert_text('There has been a problem signing you in.')
+end
+
+Then('should arrive at the user account creation error page') do
   assert_text('Sorry, there is a problem with the service')
+  assert_current_path('/response-processing')
 end
 
 Then('they should arrive at the Start page') do
   assert_text('Sign in with GOV.UK Verify')
 end
 
-Then('they arrive at the country picker') do
+Then('they should arrive at the country picker') do
   assert_text('Use a digital identity from another European country')
   assert_text('You can use a digital identity from another European country to access services on GOV.UK.')
+  assert_current_path('/choose-a-country')
 end
 
 Then('they arrive at the IdP picker') do
@@ -338,9 +347,10 @@ Then('they arrive at the confirm identity page for {string}') do |idp|
   assert_text('Sign in with '+idp)
 end
 
-Then('they arrive at the prove identity page') do
+Then('they should arrive at the prove identity page') do
   assert_text('Prove your identity to continue')
   assert_text('Choose how you want to prove your identity so you can register for an identity profile.')
+  assert_current_path('/prove-identity')
 end
 
 Then('they arrive at the about page') do
@@ -365,6 +375,12 @@ end
 
 Then('they should arrive at the Failed sign in page') do
   assert_text('You may have selected the wrong company')
+end
+
+Then('they should arrive at the Failed country sign in page') do
+  assert_text('Your identity scheme in Stub Country was unable to confirm your identity')
+  assert_text('There are other ways you can access TestRP.')
+  assert_current_path('/failed-country-sign-in')
 end
 
 Then('our Consent page should show "Level of assurance" = {string}') do |assurance_level|
@@ -399,12 +415,16 @@ And('they go back to the start page') do
   visit(URI.join(env('frontend'), 'start'))
 end
 
-When('they click {string}') do |value|
+When('they click button {string}') do |value|
   if value == ('Sign in with '+@idp)
     page.find(:xpath, "//button[contains(text(), '#{value}')]").click
   else
     page.find(:xpath, "//input[@value= '#{value}']").click
   end
+end
+
+When('they click on link {string}') do |value|
+  click_on(value)
 end
 
 Given('they login as {string} with {string} signing algorithm') do |username, algorithm|


### PR DESCRIPTION
Added tests to check that the error pages on UAC failure redirect the users to either the service start page (for Verify journeys) or to the Verify/eIDAS picker (for eIDAS journeys).

Added/modified scenarios:
- When user fails IDP signin (AuthnFailure) and clicks through link on error page, they get redirected to Verify Start page (existing behaviour)
- When user fails Country signin (AuthnFailure) and clicks through link on error page, they get redirected to Verify vs eIDAS picker
  - When they click Verify they get taken to verify start page
  - When they click eIDAS they get taken to country picker
- When user fails IDP UAC and clicks through link on error page, they get redirected to RP service error page (existing behaviour)
- When user fails Country UAC and clicks through link on error page, they get redirected to Verify vs eIDAS picker
  - When they click Verify they get taken to verify start page
  - When they click eIDAS they get taken to country picker