### PR TITLE
EID-951: Add tests to check the new error handling flow for eIDAS works correctly

### DIFF
--- a/features/authn_failure.feature
+++ b/features/authn_failure.feature
@@ -46,6 +46,10 @@ Feature: User authentication failure
     Then they should arrive at the prove identity page
     And they choose to use a European identity scheme
     Then they should arrive at the country picker
+    And they select eIDAS scheme "Stub IDP Demo"
+    Then they should be at IDP "Stub Country"
+    And they login as "stub-country"
+    Then they should be successfully verified
 
 
   @Eidas
@@ -60,6 +64,10 @@ Feature: User authentication failure
     Then they should arrive at the prove identity page
     And they choose to use Verify
     Then they should arrive at the Start page
+    And they select sign in option
+    And they select IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one"
+    Then they should be successfully verified
 
 
   Scenario: IDP returns authn failure requester error when user Signs in

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -55,6 +55,11 @@ Given('they start a journey') do
   click_on('Start')
 end
 
+Given('they select sign in option') do
+  choose('start_form_selection_false')
+  click_on('Continue')
+end
+
 Given('they start a sign in journey') do
   click_on('Start')
   click_on('Use GOV.UK Verify') if see_journey_picker?


### PR DESCRIPTION
Extended the AuthFailure tests to make sure the user can successfully sign-in with either a country or a Verify IDP after an AuthnFailure response from a country.

Modified scenarios:
- When user fails Country signin (AuthnFailure) and clicks through link on error page, they get redirected to Verify vs eIDAS picker
   - When they click Verify they get taken to verify start page and successfully log in
   - When they click eIDAS they get taken to country picker and successfully log in