### PR TITLE
HUB-280: Add tests for no cycle three, unsigned by hub

### DIFF
--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -78,6 +78,43 @@ Feature: User account creation
       | surname     | Bauer      |
       | dateofbirth | 1984-02-29 |
 
+  Scenario: Registration without cycle 3 and unsigned by hub
+    Given the user is at Test RP
+    And we set the RP name to "test-rp-not-signed-by-hub"
+    And we do not want to match the user
+    And they start a journey
+    And this is their first time using Verify
+    And they are above the age threshold
+    And they have all their documents
+    And they do not have a phone
+    And they continue to register with IDP "Stub Idp Demo One"
+    And they submit user details:
+      | firstname       | Jane       |
+      | surname         | Doe        |
+      | addressLine1    | 123        |
+      | addressLine2    | Test Drive |
+      | addressTown     | Marlbury   |
+      | addressPostCode | ABC 123    |
+      | dateOfBirth     | 1987-03-03 |
+    When they give their consent
+    Then a user should have been created with details:
+      | firstname      | Jane           |
+      | surname        | Doe            |
+      | dateofbirth    | 1987-03-03     |
+      | currentaddress | 123 Test Drive |
+
+
+  Scenario: Sign in without cycle 3 and unsigned by hub
+    Given the user is at Test RP
+    And we set the RP name to "test-rp-not-signed-by-hub"
+    And we do not want to match the user
+    And they start a sign in journey
+    And they select IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one"
+    Then a user should have been created with details:
+      | firstname   | Jack       |
+      | surname     | Bauer      |
+      | dateofbirth | 1984-02-29 |
 
   Scenario: Failed user account creation
     Given the user is at Test RP


### PR DESCRIPTION
Add tests for both sign in and registration for a text rp using
shibboleth which should not be signed by hub.

solo: @rachelthecodesmith