### PR TITLE
HUB-296: Add acceptance test for single idp feature

### DIFF
--- a/features/single_idp_journey.feature
+++ b/features/single_idp_journey.feature
@@ -1,16 +1,16 @@
-Feature: User account creation
+Feature: Single IDP journey
 
-  This tests user account creation flows.
+  This tests single IDP journey.
 
   Scenario: Single idp registration
-    Given the user is at Stub IDP Demo One
-    And they select a service from the list
+    Given the user is at the "Stub Idp Demo One" prompt page
+    When they select a service from the list
     And they are sent to Test Rp
     And we do not want to match the user
     And they start a journey
     And they land on the continue to idp page
     And they continue to the idp
-    Then they are on Stub IDP Demo One log in
+    Then they should be at IDP "Stub Idp Demo One"
     And they login as "stub-idp-demo-one"
     And they submit cycle 3 "AA123456A"
     Then a user should have been created with details:

--- a/features/single_idp_journey.feature
+++ b/features/single_idp_journey.feature
@@ -1,0 +1,21 @@
+Feature: User account creation
+
+  This tests user account creation flows.
+
+  Scenario: Single idp registration
+    Given the user is at Stub IDP Demo One
+    And they select a service from the list
+    And they are sent to Test Rp
+    And we do not want to match the user
+    And they start a journey
+    And they land on the continue to idp page
+    And they continue to the idp
+    Then they are on Stub IDP Demo One log in
+    And they login as "stub-idp-demo-one"
+    And they submit cycle 3 "AA123456A"
+    Then a user should have been created with details:
+      | firstname      | Jack       |
+      | surname        | Bauer      |
+      | dateofbirth    | 1984-02-29 |
+      | currentaddress | 1 Two St   |
+

--- a/features/step_definitions/environments.yml
+++ b/features/step_definitions/environments.yml
@@ -1,35 +1,31 @@
 local:
   frontend: http://localhost:50300
   test-rp: http://localhost:50130/test-rp
-  Single Idp Start: http://localhost:50140/stub-idp-demo-one/start-prompt
   idps:
-    Stub Country: http://localhost:50140/eidas/stub-country/login
-    Stub Idp Demo One: http://localhost:50140/stub-idp-demo-one/login
-    Stub Idp Demo Two: http://localhost:50140/stub-idp-demo-two/login
+    Stub Country: http://localhost:50140/eidas/stub-country/
+    Stub Idp Demo One: http://localhost:50140/stub-idp-demo-one/
+    Stub Idp Demo Two: http://localhost:50140/stub-idp-demo-two/
 
 docker-local:
   frontend: http://frontend
   test-rp: http://test-rp/test-rp
-  Single Idp Start: http://stub-idp/stub-idp-demo-one/start-prompt
   idps:
-    Stub Country: http://stub-idp/eidas/stub-country/login
-    Stub Idp Demo One: http://stub-idp/stub-idp-demo-one/login
-    Stub Idp Demo Two: http://stub-idp/stub-idp-demo-two/login
+    Stub Country: http://stub-idp/eidas/stub-country/
+    Stub Idp Demo One: http://stub-idp/stub-idp-demo-one/
+    Stub Idp Demo Two: http://stub-idp/stub-idp-demo-two/
 
 joint:
   frontend: https://www.joint.signin.service.gov.uk
   test-rp: https://test-rp-stub-joint.ida.digital.cabinet-office.gov.uk/test-rp
-  Single Idp Start: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-one/start-prompt
   idps:
-    Stub Country: https://ida-stub-idp-joint.cloudapps.digital/eidas/stub-country/login
-    Stub Idp Demo One: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-one/login
-    Stub Idp Demo Two: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-two/login
+    Stub Country: https://ida-stub-idp-joint.cloudapps.digital/eidas/stub-country/
+    Stub Idp Demo One: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-one/
+    Stub Idp Demo Two: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-two/
 
 staging:
   frontend: https://www.staging.signin.service.gov.uk
   test-rp: https://test-rp-stub-staging.ida.digital.cabinet-office.gov.uk/test-rp
-  Single Idp Start: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/start-prompt
   idps:
-    Stub Country: https://ida-stub-idp-staging.cloudapps.digital/eidas/stub-country/login
-    Stub Idp Demo One: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/login
-    Stub Idp Demo Two: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-two/login
+    Stub Country: https://ida-stub-idp-staging.cloudapps.digital/eidas/stub-country/
+    Stub Idp Demo One: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/
+    Stub Idp Demo Two: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-two/

--- a/features/step_definitions/environments.yml
+++ b/features/step_definitions/environments.yml
@@ -1,6 +1,7 @@
 local:
   frontend: http://localhost:50300
   test-rp: http://localhost:50130/test-rp
+  Single Idp Start: http://localhost:50140/stub-idp-demo-one/start-prompt
   idps:
     Stub Country: http://localhost:50140/eidas/stub-country/login
     Stub Idp Demo One: http://localhost:50140/stub-idp-demo-one/login
@@ -9,6 +10,7 @@ local:
 docker-local:
   frontend: http://frontend
   test-rp: http://test-rp/test-rp
+  Single Idp Start: http://stub-idp/stub-idp-demo-one/start-prompt
   idps:
     Stub Country: http://stub-idp/eidas/stub-country/login
     Stub Idp Demo One: http://stub-idp/stub-idp-demo-one/login
@@ -17,6 +19,7 @@ docker-local:
 joint:
   frontend: https://www.joint.signin.service.gov.uk
   test-rp: https://test-rp-stub-joint.ida.digital.cabinet-office.gov.uk/test-rp
+  Single Idp Start: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-one/start-prompt
   idps:
     Stub Country: https://ida-stub-idp-joint.cloudapps.digital/eidas/stub-country/login
     Stub Idp Demo One: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-one/login
@@ -25,6 +28,7 @@ joint:
 staging:
   frontend: https://www.staging.signin.service.gov.uk
   test-rp: https://test-rp-stub-staging.ida.digital.cabinet-office.gov.uk/test-rp
+  Single Idp Start: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/start-prompt
   idps:
     Stub Country: https://ida-stub-idp-staging.cloudapps.digital/eidas/stub-country/login
     Stub Idp Demo One: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/login

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -295,8 +295,9 @@ Given('they enter eidas user details:') do |details|
 end
 
 Then('they should be at IDP {string}') do |idp|
-  page = env('idps').fetch(idp)
-  assert_current_path(page, url: true)
+  idp_url = env('idps').fetch(idp)
+  page = URI.join(idp_url, 'login')
+  assert_current_path(page.to_s, url: true)
 end
 
 Then('they should be successfully verified') do
@@ -305,7 +306,7 @@ Then('they should be successfully verified') do
 end
 
 Then('they should arrive at the {string} Cancel Registration page') do |idp|
-    assert_text("Your identity verification with #{idp} has been cancelled")
+  assert_text("Your identity verification with #{idp} has been cancelled")
 end
 
 Then('they should be successfully verified with level of assurance {string}') do |assurance_level|
@@ -441,26 +442,24 @@ Given('they login as {string} with {string} signing algorithm') do |username, al
   click_on('I Agree')
 end
 
-Given('the user is at Stub IDP Demo One') do
-  visit(env('Single Idp Start'))
+Given('the user is at the {string} prompt page') do |idp|
+  idp_url = env('idps').fetch(idp)
+  prompt_page = URI.join(idp_url, 'start-prompt')
+  visit(prompt_page)
 end
 
-And('they select a service from the list') do
-  click_on('register for an identity profile')
+Given('they select a service from the list') do
+  click_on('test GOV.UK Verify user journeys')
 end
 
-And('they are sent to Test Rp') do
+Then('they are sent to Test Rp') do
   assert_current_path('/test-rp')
 end
 
-And('they land on the continue to idp page') do
+Then('they land on the continue to idp page') do
   assert_current_path('/continue-to-your-idp')
 end
 
 Given('they continue to the idp') do
   click_on('continue-to-idp-button')
-end
-
-Then('they are on Stub IDP Demo One log in') do
-  assert_current_path('/stub-idp-demo-one/login')
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -440,3 +440,27 @@ Given('they login as {string} with {string} signing algorithm') do |username, al
   page.execute_script("document.getElementById('signingAlgorithm').value = '#{algorithm}';")
   click_on('I Agree')
 end
+
+Given('the user is at Stub IDP Demo One') do
+  visit(env('Single Idp Start'))
+end
+
+And('they select a service from the list') do
+  click_on('register for an identity profile')
+end
+
+And('they are sent to Test Rp') do
+  assert_current_path('/test-rp')
+end
+
+And('they land on the continue to idp page') do
+  assert_current_path('/continue-to-your-idp')
+end
+
+Given('they continue to the idp') do
+  click_on('continue-to-idp-button')
+end
+
+Then('they are on Stub IDP Demo One log in') do
+  assert_current_path('/stub-idp-demo-one/login')
+end


### PR DESCRIPTION
Add acceptance test for the single idp feature to ensure a journey can
be made from the appropriate pages so long as the feature flag is
enabled.

@rachelthecodesmith