### PR TITLE
EID-1004: Test transitions from eIDAS to Verify journeys

### DIFF
--- a/features/back_button.feature
+++ b/features/back_button.feature
@@ -15,6 +15,25 @@ Feature: User Back button
     Then they should be successfully verified
 
 
+  @Eidas
+  Scenario: User selects a country and then goes back to select a Verify IDP
+    Given the user is at Test RP
+    When they start an eIDAS journey
+    Then they should arrive at the country picker
+    And they select eIDAS scheme "Stub IDP Demo"
+    Then they should be at IDP "Stub Country"
+
+    When they go back to the journey picker page
+    And they choose to use Verify
+    Then they should arrive at the Start page
+    And they select sign in option
+
+    And they select IDP "Stub Idp Demo One"
+    Then they should be at IDP "Stub Idp Demo One"
+    And they login as "stub-idp-demo-one"
+    Then they should be successfully verified
+
+
   Scenario: User selects sign in then goes back to select registration
     Given the user is at Test RP
     When they start a sign in journey
@@ -35,6 +54,4 @@ Feature: User Back button
     And they continue to register with IDP "Stub Idp Demo One"
     And they want to cancel registration
     Then they should arrive at the "Stub Idp Demo One" Cancel Registration page
-
-
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -141,6 +141,11 @@ Given('they go back to the country picker') do
   assert_text('Use a digital identity from another European country')
 end
 
+Given('they go back to the journey picker page') do
+  visit(URI.join(env('frontend'), 'prove-identity'))
+  assert_text('Prove your identity to continue')
+end
+
 Given('they login as {string}') do |username|
   fill_in('username', with: username)
   fill_in('password', with: 'bar')


### PR DESCRIPTION
This checks that when users select a country they can go back to the journey picker page and successfully log in with a Verify IDP

Added scenario:
- User starts an eIDAS journey, selects a country, then goes back to journey picker page, signs in with an IDP and succeeds

Note: this can only be merged after alphagov/verify-hub#155 and alphagov/verify-frontend#589