### PR TITLE
CVQ2-227: Add new acceptance test for disconnected IDPs

### DIFF
--- a/features/simple.feature
+++ b/features/simple.feature
@@ -31,3 +31,12 @@ Feature: User simple flows - sign in and registeration
     When they give their consent
     Then they should be successfully verified
 
+  Scenario: User cannot register with a disconnected IDP
+    Given the user is at Test RP
+    And they start a journey
+    And this is their first time using Verify
+    And they are above the age threshold
+    And they have all their documents
+    And they have a smart phone
+    Then they cannot continue to register with disconnected IDP "Stub Idp Demo Three"
+    

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -204,6 +204,10 @@ Given('they continue to register with IDP {string}') do |idp|
   @idp = "#{idp}"
 end
 
+Then('they cannot continue to register with disconnected IDP {string}') do |idp|
+  assert_no_text("Choose #{idp}")
+end
+
 Given('they register for an LOA1 profile with IDP {string}') do |idp|
   click_on("Choose #{idp}")
   assert_text('Create your ' + idp + ' identity account')


### PR DESCRIPTION
This PR adds a new acceptance tests to ensure that users cannot register with an IDP no longer providing new user registrations.

Solo: @karlbaker02