### PR TITLE
CVQ2-227: Add test for hard-disconnection

### DIFF
--- a/features/simple.feature
+++ b/features/simple.feature
@@ -39,4 +39,8 @@ Feature: User simple flows - sign in and registeration
     And they have all their documents
     And they have a smart phone
     Then they cannot continue to register with disconnected IDP "Stub Idp Demo Three"
-    
+
+  Scenario: User cannot sign in using a disconnected IDP
+    Given the user is at Test RP
+    And they start a sign in journey
+    Then they cannot sign in with IDP "Stub Idp Demo Three"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -219,6 +219,10 @@ Given('they select IDP {string}') do |idp|
   click_on("Select #{idp}", match: :prefer_exact)
 end
 
+Then('they cannot sign in with IDP {string}') do |idp|
+  assert_no_text("Select #{idp}")
+end
+
 Given('the IDP returns an Authn Failure response') do
   click_on('tab-login')
   click_on('Authn Failure')


### PR DESCRIPTION
This PR tests that the hard-disconnection (sign-in) does not display an IDP no longer providing authentication.

Solo: @karlbaker02