### PR TITLE
EID-1116 Tidy up verify-acceptance-test step definition

### DIFF
--- a/features/account_creation.feature
+++ b/features/account_creation.feature
@@ -67,7 +67,6 @@ Feature: User account creation
       | dateofbirth    | 1987-03-03     |
       | currentaddress | 123 Test Drive |
 
-
   Scenario: Sign in without cycle 3
     Given the user is at Test RP
     And we set the RP name to "test-rp-noc3"
@@ -105,7 +104,6 @@ Feature: User account creation
       | surname        | Doe            |
       | dateofbirth    | 1987-03-03     |
       | currentaddress | 123 Test Drive |
-
 
   Scenario: Sign in without cycle 3 and unsigned by hub
     Given the user is at Test RP

--- a/features/eidas_user_journeys.feature
+++ b/features/eidas_user_journeys.feature
@@ -66,7 +66,6 @@ Feature: eIDAS user journeys
       | surname     | Doe        |
       | dateofbirth | 1987-03-03 |
 
-
   @Eidas
   Scenario: User signs creates a new account
     Given the user is at Test RP

--- a/features/non_repudiation.feature
+++ b/features/non_repudiation.feature
@@ -25,5 +25,5 @@ Feature: User registers, returns to confirm identity and signs in successfully
     When they click button "Confirm Identity"
     Then they arrive at the confirm identity page for "Stub Idp Demo Two"
     When they click button "Sign in with Stub Idp Demo Two"
-    And they login as the newly registered user
+    And they login as "the newly registered user"
     Then they should be successfully verified with level of assurance "LEVEL_2"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -39,6 +39,13 @@ def page_heading_text(page)
   end
 end
 
+def log_in_as(username)
+  fill_in('username', with: username)
+  fill_in('password', with: 'bar')
+  click_on('SignIn')
+  assert_text("You've successfully authenticated")
+end
+
 Before do
   visit(env('frontend')+"/cookies")
   Capybara.reset_sessions!
@@ -151,26 +158,13 @@ Given('they click Register') do
   click_on('Register')
 end
 
-Given('they login as {string}') do |username|
-  fill_in('username', with: username)
-  fill_in('password', with: 'bar')
-  click_on('SignIn')
-  click_on('I Agree')
-end
+Given(/^they login as "(.*)"( with a random pid)?$/) do |user_string, with_random_pid|
+  if user_string == "the newly registered user"
+    user_string = @username
+  end
 
-Given('they login as the newly registered user') do
-  fill_in('username', with: @username)
-  fill_in('password', with: 'bar')
-  click_on('SignIn')
-  click_on('I Agree')
-end
-
-Given('they login as {string} with a random pid') do |username|
-  fill_in('username', with: username)
-  fill_in('password', with: 'bar')
-  click_on('SignIn')
-  assert_text("You've successfully authenticated")
-  page.execute_script('document.getElementById("randomPid").value = "true"')
+  log_in_as(user_string)
+  page.execute_script('document.getElementById("randomPid").value = "true"') if with_random_pid
   click_on('I Agree')
 end
 
@@ -452,10 +446,7 @@ When('they click on link {string}') do |value|
 end
 
 Given('they login as {string} with {string} signing algorithm') do |username, algorithm|
-  fill_in('username', with: username)
-  fill_in('password', with: 'bar')
-  click_on('SignIn')
-  assert_text("You've successfully authenticated")
+  log_in_as(username)
   page.execute_script("document.getElementById('signingAlgorithm').value = '#{algorithm}';")
   click_on('I Agree')
 end


### PR DESCRIPTION
EID-1116 Tidy up verify-acceptance-test step definition

    - Consolidate the following step definitions into one:
    Given('they login as {string}') do |username|
    Given('they login as the newly registered user')

    Above two replaced with:
    Given(/^they login as "(.*)"( with a random pid)?$/) do |user_string, with_random_pid|

    - Create a login function to replace repeated chunk of code that execute user login
    def log_in_as(username)
      fill_in('username', with: username)
      fill_in('password', with: 'bar')
      click_on('SignIn')
      assert_text("You've successfully authenticated")
    end