### PR TITLE
BAU: Make number of nodes configurable

### DIFF
--- a/run-tests-with-docker-parallel.sh
+++ b/run-tests-with-docker-parallel.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env sh
 set -u
 
+: "${NODES:=3}"
+
 docker-compose -f docker-compose-parallel.yml build verify-tests
-docker-compose -f docker-compose-parallel.yml up -d --scale firefoxnode=3 selenium-hub firefoxnode 
-echo "Waiting 5s for the nodes to join the selenium hub"
-sleep 5
+docker-compose -f docker-compose-parallel.yml up -d --scale firefoxnode=$NODES selenium-hub firefoxnode 
+echo "Waiting $((2+$NODES)) seconds for the nodes to join the selenium hub"
+sleep $((2+$NODES))
 docker-compose -f docker-compose-parallel.yml \
                run \
                --name verify-tests \
                -e TEST_ENV=${TEST_ENV:-"joint"} \
-               verify-tests -n 3 -o "--strict -f pretty -f junit -o testreport/ $*"
+               verify-tests -n $NODES -o "--strict -f pretty -f junit -o testreport/ $*"
 exit_status=$?
 docker cp $(docker ps -a -q -f name="verify-tests"):/testreport .
 docker-compose -f docker-compose-parallel.yml down 


### PR DESCRIPTION
We might benefit a bit more from a greater parallelization. This will enable us
to run and test the optimal number of nodes.

Corresponding JJB change https://github.com/alphagov/verify-jenkins-job-builder/pull/312