### PR TITLE
EID-1060 Acceptance tests for eIDAS scheme unavailable error message

### DIFF
--- a/features/eidas_journeys.feature
+++ b/features/eidas_journeys.feature
@@ -52,3 +52,10 @@ Feature: eIDAS user journeys
     And they select IDP "Stub IDP Demo"
     And they login as "stub-country" with "rsassa-pss" signing algorithm
     Then they should be successfully verified
+
+  @Eidas
+  Scenario: User selects unavailable eIDAS scheme and arrives at the correct error page
+    Given the user is at Test RP
+    When they start an eIDAS journey
+    And they select eIDAS scheme "Invalid Scheme"
+    Then they should arrive at the eIDAS scheme unavailable error page

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -401,13 +401,17 @@ Then('they should arrive at the Failed country sign in page') do
   assert_current_path('/failed-country-sign-in')
 end
 
-Then('our Consent page should show "Level of assurance" = {string}') do |assurance_level|
+Then('they should arrive at the eIDAS scheme unavailable error page') do
+  assert_current_path('/redirect-to-country')
+  assert_text(/Your identity scheme in .* is currently unavailable/)
+end
 
+Then('our Consent page should show "Level of assurance" = {string}') do |assurance_level|
   assert_text("You've successfully authenticated with #{@idp}")
   assert_text("#{assurance_level}")
 end
 
-Then ('they are shown the cookies missing page') do
+Then('they are shown the cookies missing page') do
   assert_text('GOV.UK Verify can only be accessed from a government service.')
   assert_text("If you can’t access GOV.UK Verify from a service, enable your cookies.")
 end

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -2,9 +2,9 @@
 
 set -eu
 
-if [ "${1:-}" == "--no-parallel" ]
+if [[ "${1:-}" == "--no-parallel" ]]
 then
-    SHOW_BROWSER=true
+    SHOW_BROWSER=${SHOW_BROWSER:-true}
     INSTANCES=1
 fi
 


### PR DESCRIPTION
Added scenarios:
  Scenario: English journey - User selects eIDAS scheme that is unavailable and receives correct error page
  Scenario: Welsh journey - User selects eIDAS scheme that is unavailable and receives correct error page

Added step definitions:
Given /a user starts the "(.*)" version of the eIDAS journey$/ do |language_version|
Then('they are presented with the correct eIDAS scheme unavailable error page') do

Modified step definition:
Given('they select eIDAS scheme {string}') do |scheme|