### PR TITLE
BAU: Ignore .gems folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gems
 .idea
 testreport
 *.iml


### PR DESCRIPTION
.gems folder is created after running hub acceptance test. It prevents update_project_repos script in verify-build-scripts repo from updating verify-acceptance-tests.

Author: @adityapahuja