### PR TITLE
BAU: Run tests on the latest Firefox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     build: .
 
   selenium-hub:
-    image: selenium/hub:3.14.0-iron
+    image: selenium/hub
     ports:
       - "4444:4444"
 
   firefoxnode:
-    image: selenium/node-firefox:3.14.0-iron
+    image: selenium/node-firefox
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT_4444_TCP_PORT=4444


### PR DESCRIPTION
The recent capybara and geckodriver updates allow us to run the tests with the
latest Firefox version. No need to peg the version (yay).