### PR TITLE
BAU_run_selected_tests

### DIFF
--- a/run-selected-tests.sh
+++ b/run-selected-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+cd `dirname $0`
+
+set -eu
+
+TESTS=""
+
+while (( $# )); do
+    if [[ "${1:-}" == "--show-browser" ]]
+    then
+        SHOW_BROWSER="true"
+    else
+        TESTS="$TESTS $1"
+    fi
+    shift
+done
+
+bundle --quiet
+mkdir -p testreport
+SHOW_BROWSER=${SHOW_BROWSER:-"false"} TEST_ENV=local bundle exec cucumber --strict $TESTS


### PR DESCRIPTION
Parallel cucumber tests mean that if a test fails and needs to be run again the whole feature is the smallest unit that can be selected and requires the pre-commit script to be edited.

Add script to take arguments of the form feature/some_test.feature:9 to run only the test starting at line 9 of some_test.feature.  Multiple tests of that format can be specified if more than one test is failing.  An optional argument of --show-browser can be specified.