### PR TITLE
Enable use of selenium.tools.signin.service.gov.uk

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,7 +10,23 @@ show_browser = ENV['SHOW_BROWSER'] == 'true'
 
 ### Driver config ###
 
-if ENV['TEST_ENV'] == 'local' || ENV['SHOW_BROWSER']
+if ENV.key?('SELENIUM_HUB_URL')
+  selenium_hub_url    = "#{ENV.fetch('SELENIUM_HUB_URL')}/wd/hub"
+  caps                = Selenium::WebDriver::Remote::Capabilities.firefox
+  Capybara.run_server = false
+
+  Capybara.register_driver :remote_browser do |app|
+		Capybara::Selenium::Driver.new(
+			app,
+			:browser => :remote,
+			url: selenium_hub_url,
+			desired_capabilities: caps
+		)
+	end
+
+	Capybara.default_driver    = :remote_browser
+	Capybara.javascript_driver = :remote_browser
+elsif ENV['TEST_ENV'] == 'local' || ENV['SHOW_BROWSER']
   Capybara.register_driver :firefox_driver do |app|
     options = ::Selenium::WebDriver::Firefox::Options.new
     options.args << '--headless' unless show_browser


### PR DESCRIPTION
What
----

We have a selenium hub running at selenium.tools.signin.service.gov.uk

We would like to use it for parallel acceptance tests without the use of
docker compose

When passing the `SELENIUM_HUB_URL` environment variable this will use a
remote selenium hub

How to review
----

```
# Be on the VPN
$ git fetch
$ git checkout -b enable-use-of-tools-selenium origin/enable-use-of-tools-selenium
$ bundle install
$ SELENIUM_HUB_URL="https://selenium.tools.signin.service.gov.uk" \
  TEST_ENV=joint \
  bundle exec parallel_cucumber -n 2 features
```