### PR TITLE
HKYawdAT: Add integration test for disconnected IDP hints

### DIFF
--- a/features/simple_sign_in.feature
+++ b/features/simple_sign_in.feature
@@ -13,7 +13,21 @@ Feature: User simple flows - sign in
   Scenario: User cannot sign in using a disconnected IDP
     Given the user is at Test RP
     And they start a sign in journey
-    Then they cannot sign in with IDP "Stub Idp Demo Three"
+    Then they cannot sign in with IDP "Stub Idp Disconnected"
+
+  Scenario: User can see disconnected IDP hint
+    Given the user is at Test RP
+    And they start a registration journey with IDP "Stub Idp Disconnected"
+    And they submit user details:
+      | firstname       | Jane       |
+      | surname         | Doe        |
+      | addressLine1    | 123        |
+      | addressLine2    | Test Drive |
+      | addressTown     | Marlbury   |
+      | addressPostCode | ABC 123    |
+      | dateOfBirth     | 1987-03-03 |
+    And they finish registering
+    Then they should see the disconnected IDP hint for "Stub Idp Disconnected"
 
   Scenario: Sign in without cycle 3 and unsigned by hub
     Given the user is at Test RP

--- a/features/simple_sign_in.feature
+++ b/features/simple_sign_in.feature
@@ -27,6 +27,8 @@ Feature: User simple flows - sign in
       | addressPostCode | ABC 123    |
       | dateOfBirth     | 1987-03-03 |
     And they finish registering
+    And the user is at Test RP
+    And they start a sign in journey
     Then they should see the disconnected IDP hint for "Stub Idp Disconnected"
 
   Scenario: Sign in without cycle 3 and unsigned by hub

--- a/features/step_definitions/environments.yml
+++ b/features/step_definitions/environments.yml
@@ -5,6 +5,7 @@ local:
     Stub Country: http://localhost:50140/eidas/stub-country/
     Stub Idp Demo One: http://localhost:50140/stub-idp-demo-one/
     Stub Idp Demo Two: http://localhost:50140/stub-idp-demo-two/
+    Stub Idp Disconnected: http://localhost:50140/stub-idp-disconnected/
 
 docker-local:
   frontend: http://frontend
@@ -13,6 +14,7 @@ docker-local:
     Stub Country: http://stub-idp/eidas/stub-country/
     Stub Idp Demo One: http://stub-idp/stub-idp-demo-one/
     Stub Idp Demo Two: http://stub-idp/stub-idp-demo-two/
+    Stub Idp Disconnected: http://stub-idp/stub-idp-disconnected/
 
 joint:
   frontend: https://www.joint.signin.service.gov.uk
@@ -21,6 +23,7 @@ joint:
     Stub Country: https://ida-stub-idp-joint.cloudapps.digital/eidas/stub-country/
     Stub Idp Demo One: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-one/
     Stub Idp Demo Two: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-demo-two/
+    Stub Idp Disconnected: https://ida-stub-idp-joint.cloudapps.digital/stub-idp-disconnected/
 
 staging:
   frontend: https://www.staging.signin.service.gov.uk
@@ -29,3 +32,4 @@ staging:
     Stub Country: https://ida-stub-idp-staging.cloudapps.digital/eidas/stub-country/
     Stub Idp Demo One: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-one/
     Stub Idp Demo Two: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-demo-two/
+    Stub Idp Disconnected: https://ida-stub-idp-staging.cloudapps.digital/stub-idp-disconnected/

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -556,6 +556,5 @@ And('they finish registering') do
   step('they give their consent')
   step('they click continue on the confirmation page')
   step('they should be successfully verified')
-  click_on('Confirm Identity')
-  click_on('sign in with a different certified company')
+  click_on('Logout')
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -547,3 +547,15 @@ end
 Given('the IDP fails to authenticate user') do
   click_on('Authn Failure')
 end
+
+Then('they should see the disconnected IDP hint for {string}') do |idp|
+  assert_text("This is tailored text for when #{idp} is disconnected")
+end
+
+And('they finish registering') do
+  step('they give their consent')
+  step('they click continue on the confirmation page')
+  step('they should be successfully verified')
+  click_on('Confirm Identity')
+  click_on('sign in with a different certified company')
+end


### PR DESCRIPTION
See https://trello.com/c/HKYawdAT/133-add-integration-test-for-disconnected-idp-hints

Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>