### PR TITLE
EID-1611 tests for unsigned assertion journeys

### DIFF
--- a/features/eidas_journeys.feature
+++ b/features/eidas_journeys.feature
@@ -37,7 +37,7 @@ Feature: eIDAS user journeys
     Then they should be successfully verified
 
   @Eidas
-  Scenario: User signs in with a country and does Cycle 3
+  Scenario: User signs in with a country and does Cycle 3 for an ambiguous match
     Given the user is at Test RP
     And they start an eIDAS journey
     And they select IDP "Stub IDP Demo"
@@ -59,3 +59,22 @@ Feature: eIDAS user journeys
     When they start an eIDAS journey
     And they select eIDAS scheme "Invalid Scheme"
     Then they should arrive at the eIDAS scheme unavailable error page
+
+  @Eidas
+  Scenario: User signs in with a country that provides unsigned assertions
+    Given the user is at Test RP
+    And they start an eIDAS journey
+    And they select IDP "Stub IDP Demo"
+    And they choose unsigned assertions
+    And they login as "stub-country"
+    Then they should be successfully verified
+
+  @Eidas
+  Scenario: User signs in with a country that provides unsigned assertions and does Cycle 3 for an ambiguous match
+    Given the user is at Test RP
+    And they start an eIDAS journey
+    And they select IDP "Stub IDP Demo"
+    And they choose unsigned assertions
+    And they login as "stub-country-ec3"
+    And they submit cycle 3 "AA123456A"
+    Then they should be successfully verified

--- a/features/eidas_journeys_account_creation.feature
+++ b/features/eidas_journeys_account_creation.feature
@@ -31,3 +31,35 @@ Feature: eIDAS user journeys with user account creation
       | firstname   | Jack       |
       | surname     | Bauer      |
       | dateofbirth | 1984-02-29 |
+
+  @Eidas
+  Scenario: User registers with stub country, for unsigned assertions, with cycle3, and forces UAC
+    Given the user is at Test RP
+    And we do not want to match the user
+    And they start an eIDAS journey
+    And they select IDP "Stub IDP Demo"
+    And they choose unsigned assertions
+    And they click Register
+    And they enter eidas user details:
+      | firstname   | Bob        |
+      | surname     | Doe        |
+      | dateOfBirth | 1987-03-03 |
+    And they submit cycle 3 "AA123456A"
+    Then a user should have been created with details:
+      | firstname   | Bob        |
+      | surname     | Doe        |
+      | dateofbirth | 1987-03-03 |
+
+  @Eidas
+  Scenario: User signs and creates a new account with stub country, for unsigned assertions
+    Given the user is at Test RP
+    And we do not want to match the user
+    And they start an eIDAS journey
+    And they select IDP "Stub IDP Demo"
+    And they choose unsigned assertions
+    And they login as "stub-country"
+    And they submit cycle 3 "AA123456A"
+    Then a user should have been created with details:
+      | firstname   | Jack       |
+      | surname     | Bauer      |
+      | dateofbirth | 1984-02-29 |

--- a/features/eidas_journeys_account_creation.feature
+++ b/features/eidas_journeys_account_creation.feature
@@ -51,7 +51,7 @@ Feature: eIDAS user journeys with user account creation
       | dateofbirth | 1987-03-03 |
 
   @Eidas
-  Scenario: User signs and creates a new account with stub country, for unsigned assertions
+  Scenario: User signs in and creates a new account with stub country, for unsigned assertions
     Given the user is at Test RP
     And we do not want to match the user
     And they start an eIDAS journey

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -168,6 +168,14 @@ Given(/^they login as "(.*)"( with a random pid)?$/) do |user_string, with_rando
   click_on('I Agree')
 end
 
+And('they choose unsigned assertions') do
+  all('input[type=checkbox][value="signAssertions"]').each do |checkbox|
+    if checkbox.checked? then 
+      checkbox.click
+    end
+  end
+end
+
 Given('they submit cycle 3 {string}') do |string|
   fill_in('cycle_three_attribute[cycle_three_data]', with: string)
   click_on('Continue')

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -169,11 +169,7 @@ Given(/^they login as "(.*)"( with a random pid)?$/) do |user_string, with_rando
 end
 
 And('they choose unsigned assertions') do
-  all('input[type=checkbox][value="signAssertions"]').each do |checkbox|
-    if checkbox.checked? then 
-      checkbox.click
-    end
-  end
+  uncheck("assertionOptions_signAssertions")
 end
 
 Given('they submit cycle 3 {string}') do |string|


### PR DESCRIPTION
Adds new tests for:

- regular journeys where the stub country provides unsigned assertions
- account creation journeys where the stub country provides unsigned assertions

**Merge EID-1604 before this PR.**