### PR TITLE
Add MSA backward compatibility tests

### DIFF
--- a/features/backward_compatibility.feature
+++ b/features/backward_compatibility.feature
@@ -1,0 +1,18 @@
+@staging-only
+Feature: Compatibility with old supported MSA versions
+  These tests check that the hub works correctly with old supported
+  MSA versions.
+
+  Scenario Outline: Sign in successful with IDP and cycle 3
+    Given the user is at "<RP>"
+    And they start a sign in journey
+    And they select IDP "Stub Idp Demo Two"
+    And they login as "stub-idp-demo-two-c3"
+    And they submit cycle 3 "AA123456A"
+    Then they should be successfully verified
+
+  Examples:
+    | RP                                                              |
+    | https://test-rp-staging-backcompat-1.cloudapps.digital/test-rp/ |
+    | https://test-rp-staging-backcompat-2.cloudapps.digital/test-rp/ |
+    | https://test-rp-staging-backcompat-3.cloudapps.digital/test-rp/ |

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -56,6 +56,11 @@ Given('the user is at Test RP') do
   @see_journey_picker = true
 end
 
+Given('the user is at {string}') do |url|
+  visit(url)
+  @see_journey_picker = true
+end
+
 Given('we do not want to match the user') do
   check('no-match')
 end


### PR DESCRIPTION
This adds tests for MSA backward compatibility.  They reproduce the
old ida-hub-acceptance-tests/msa-backward-compatibility-test.sh which
ran
MsaBackwardsCompatibilityTest.userSignInSuccessfullyAndCompletesNINOCycle3Page.

Basically it's a simple login flow with cycle 3.

The purpose of these tests is that they are run against a separate
test-rp/msa instance, which are running an old but supported version
of the MSA.  These MSAs are already deployed to PaaS and have
pipelines to deploy them.

It's not ideal to hardcode the MSA URL in the feature but I couldn't
think of a better way to achieve this.  I'm open to suggestions.

I have run these locally and they pass :+1: so we are still backwards
compatible, hooray!