### PR TITLE
EID-1917: Add smoke tests to all countries connected to Connector Node

### DIFF
--- a/features/eidas/be-request.feature
+++ b/features/eidas/be-request.feature
@@ -1,0 +1,9 @@
+Feature: eidas-connector-node-smoke-test-be-prod
+
+    This tests the Belgium connector node
+
+    Scenario: Connector node happy path for Belgium
+        Given   the user visits a Government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Belgium
+        Then    they should arrive at the Belgium Hub

--- a/features/eidas/es-request.feature
+++ b/features/eidas/es-request.feature
@@ -1,0 +1,9 @@
+Feature: eidas-connector-node-smoke-test-es-prod
+
+    This tests the Spain connector node
+
+    Scenario: Connector node happy path for Spain
+        Given   the user visits a Government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Spain
+        Then    they should arrive at the Spain Hub

--- a/features/eidas/et-request.feature
+++ b/features/eidas/et-request.feature
@@ -1,0 +1,10 @@
+Feature: eidas-connector-node-smoke-test-et-prod
+
+    This tests the Estonia connector node
+
+    Scenario: Connector node happy path for Estonia
+        Given   the user visits a Government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Estonia
+        And     they navigate through Eidas
+        Then    they should arrive at the Estonia Hub

--- a/features/eidas/it-request.feature
+++ b/features/eidas/it-request.feature
@@ -1,0 +1,10 @@
+Feature: eidas-connector-node-smoke-test-it-prod
+
+    This tests the Italy connector node
+
+    Scenario: Connector node happy path for Italy
+        Given   the user visits a Government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Italy
+        And     they navigate through Eidas
+        Then    they should arrive at the Italy Hub

--- a/features/eidas/lu-request.feature
+++ b/features/eidas/lu-request.feature
@@ -1,0 +1,9 @@
+Feature: eidas-connector-node-smoke-test-lu-prod
+
+    This tests the Luxembourg connector node
+
+    Scenario: Connector node happy path for Luxembourg
+        Given   the user visits a Government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Luxembourg
+        Then    they should arrive at the Luxembourg Hub

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -568,3 +568,59 @@ And('they finish registering') do
   step('they should be successfully verified')
   click_on('Logout')
 end
+
+Given("the user visits a Government service") do
+  visit('https://www.gov.uk/personal-tax-account/sign-in/prove-identity')
+end
+
+And('they choose sign in with a digital identity from another European country') do
+  find('label', text: 'Sign in with a digital identity from another European country').click
+  click_button('Continue')
+end
+
+And('they select Spain') do
+  click_button('Select DNIe')
+end
+
+Then('they should arrive at the Spain Hub') do
+  assert_text('Identificación con DNIe')
+end
+
+And('they select Estonia') do
+  click_button('Select ID-kaart')
+end
+
+Then('they should arrive at the Estonia Hub') do
+  assert_text('Turvaliseks autentimiseks Euroopa e-teenustes')
+end 
+
+And('they select Italy') do
+  click_button('Select SPID')
+end
+
+Then('they should arrive at the Italy Hub') do
+  assert_text('Italian eIDAS Login')
+end 
+
+And('they select Luxembourg') do
+  click_button('Select eAccess')
+end
+
+Then('they should arrive at the Luxembourg Hub') do
+  assert_text('eIDAS Authentication Service')
+end 
+
+And('they select Belgium') do
+  click_button('Select CSAM')
+end
+
+Then('they should arrive at the Belgium Hub') do
+  assert_text('Choose your digital key to log in')
+end 
+
+And('they navigate through Eidas') do
+  assert_text('YOUR BASIC INFORMATION')
+  click_button('Next')
+  assert_text('YOUR ADDITIONAL INFORMATION')
+  click_button('Next')
+end


### PR DESCRIPTION
Added a smoke test to the existing infrastructure for all countries connected to the Connector Node in prod
These countries are currently: Estonia, Italy, Luxembourg, Spain, Belgium
(Germany uses middleware so is excluded)

The tests all start from the 'Personal tax account' service. From here sign in with a digital identity from another European country is selected. Then the country of choice is selected and then we check that we have reached the countries hub by asserting we can see specialised text on the page.

Add a smoke test for each country to the Verify Hub Smoke pipeline: https://github.com/alphagov/verify-terraform/pull/1162
