### PR TITLE
BAU: Add tags to eIDAS tests for integration with real countries

### DIFF
--- a/features/eidas_countries_integration/be-request.feature
+++ b/features/eidas_countries_integration/be-request.feature
@@ -2,6 +2,7 @@ Feature: eidas-connector-node-smoke-test-be-prod
 
     This tests the Belgium connector node
 
+    @EidasIntegration
     Scenario: Connector node happy path for Belgium
         Given   the user visits a Government service
         And     they choose sign in with a digital identity from another European country

--- a/features/eidas_countries_integration/es-request.feature
+++ b/features/eidas_countries_integration/es-request.feature
@@ -2,6 +2,7 @@ Feature: eidas-connector-node-smoke-test-es-prod
 
     This tests the Spain connector node
 
+    @EidasIntegration
     Scenario: Connector node happy path for Spain
         Given   the user visits a Government service
         And     they choose sign in with a digital identity from another European country

--- a/features/eidas_countries_integration/et-request.feature
+++ b/features/eidas_countries_integration/et-request.feature
@@ -2,6 +2,7 @@ Feature: eidas-connector-node-smoke-test-et-prod
 
     This tests the Estonia connector node
 
+    @EidasIntegration
     Scenario: Connector node happy path for Estonia
         Given   the user visits a Government service
         And     they choose sign in with a digital identity from another European country

--- a/features/eidas_countries_integration/it-request.feature
+++ b/features/eidas_countries_integration/it-request.feature
@@ -2,6 +2,7 @@ Feature: eidas-connector-node-smoke-test-it-prod
 
     This tests the Italy connector node
 
+    @EidasIntegration
     Scenario: Connector node happy path for Italy
         Given   the user visits a Government service
         And     they choose sign in with a digital identity from another European country

--- a/features/eidas_countries_integration/lu-request.feature
+++ b/features/eidas_countries_integration/lu-request.feature
@@ -2,6 +2,7 @@ Feature: eidas-connector-node-smoke-test-lu-prod
 
     This tests the Luxembourg connector node
 
+    @EidasIntegration
     Scenario: Connector node happy path for Luxembourg
         Given   the user visits a Government service
         And     they choose sign in with a digital identity from another European country


### PR DESCRIPTION
This is so we can exclude these tests from the Hub deploy pipeline