### PR TITLE
HUB-553: Reflect changes to the registration journey in the tests

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -213,6 +213,7 @@ end
 
 Given('they continue to register with IDP {string}') do |idp|
   click_on("Choose #{idp}")
+  click_on('Continue')
   click_on("Continue to the #{idp} website")
   @idp = "#{idp}"
 end

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -10,4 +10,4 @@ fi
 
 bundle --quiet
 mkdir -p testreport
-SHOW_BROWSER=${SHOW_BROWSER:-false} TEST_ENV=local bundle exec parallel_cucumber features/ -n ${INSTANCES:-3} -o "--strict"
+SHOW_BROWSER=${SHOW_BROWSER:-false} TEST_ENV=${TEST_ENV:-local} bundle exec parallel_cucumber features/ -n ${INSTANCES:-3} -o "--strict"


### PR DESCRIPTION
New journey was introduced in alphagov/verify-frontend#818

Also allow to specify the environment as an env var when running pre-commit