### PR TITLE
BAU: Remove prompt to try with another IDP on registration failure

### DIFF
--- a/features/authn_failure.feature
+++ b/features/authn_failure.feature
@@ -16,8 +16,8 @@ Feature: User authentication failure
     When the IDP returns an Authn Failure response
     Then they should arrive at the Failed registration page
 
-    When they select the link find another company to verify you
-    Then they should arrive at the Select documents page
+#    When they select the link find another company to verify you
+#    Then they should arrive at the Select documents page
 
 
   Scenario: IDP returns authn failure when user Signs in

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -10,4 +10,4 @@ fi
 
 bundle --quiet
 mkdir -p testreport
-SHOW_BROWSER=${SHOW_BROWSER:-false} TEST_ENV=${TEST_ENV:-local} bundle exec parallel_cucumber features/ -n ${INSTANCES:-3} -o "--strict"
+SHOW_BROWSER=${SHOW_BROWSER:-false} TEST_ENV=${TEST_ENV:-local} bundle exec parallel_cucumber features/ -n ${INSTANCES:-3} -o "--strict --tags 'not @ignore'"


### PR DESCRIPTION
Due to changes in alphagov/verify-frontend#821

This is because due to traffic splitting the user will only ever see one IDP.
This is a temporary measure until we fix the splitting logic to be more clever.

Also ignore tests marked with `@ignore` when running locally