### PR TITLE
Hub 662 remove content and pages about weird journeys

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -218,7 +218,6 @@ end
 
 Given('they continue to register with IDP {string}') do |idp|
   click_on("Choose #{idp}")
-  click_on('Continue')
   click_on("Continue to the #{idp} website")
   @idp = "#{idp}"
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -229,8 +229,7 @@ end
 
 Given('they register for an LOA1 profile with IDP {string}') do |idp|
   click_on("Choose #{idp}")
-  click_on('Continue')
-  assert_text(idp)
+  assert_text('Create your ' + idp + ' identity account')
   click_on("Continue to the #{idp} website")
   @idp = "#{idp}"
 end


### PR DESCRIPTION
See https://govukverify.atlassian.net/browse/HUB-662
**What**

When Covid-19 caused huge peaks in traffic for UC, we added stuff to the hub to:
manage expectations about the IDP delays
explain that users would need to go back to the service after the IDP
These changes appear in the registration users journey after the user selects an IDP on the IDP picker page.

**Why**

- Because we are now reverting see: https://github.com/alphagov/verify-frontend/pull/864
- Above affects **acceptance test** as the warning page will be removed


