### PR TITLE
Organise eIDAS Connector Node smoke tests

### DIFF
--- a/features/smoke/eidas_connector_node/integration/portugal.feature
+++ b/features/smoke/eidas_connector_node/integration/portugal.feature
@@ -1,4 +1,4 @@
-Feature: eidas-connector-node-smoke-test-pt-prod
+Feature: eIDAS Connector Node Smoke Test - Portugal - Integration
 
     This tests the connection of the UK Connector Node to the Portuguese Proxy Node
 

--- a/features/smoke/eidas_connector_node/production/belgium.feature
+++ b/features/smoke/eidas_connector_node/production/belgium.feature
@@ -1,4 +1,4 @@
-Feature: eidas-connector-node-smoke-test-be-prod
+Feature: eIDAS Connector Node Smoke Test - Belgium - Production
 
     This tests the connection of the UK Connector Node to the Belgian Proxy Node
 

--- a/features/smoke/eidas_connector_node/production/estonia.feature
+++ b/features/smoke/eidas_connector_node/production/estonia.feature
@@ -1,4 +1,4 @@
-Feature: eidas-connector-node-smoke-test-et-prod
+Feature: eIDAS Connector Node Smoke Test - Estonia - Production
 
     This tests the connection of the UK Connector Node to the Estonian Proxy Node
 

--- a/features/smoke/eidas_connector_node/production/italy.feature
+++ b/features/smoke/eidas_connector_node/production/italy.feature
@@ -1,4 +1,4 @@
-Feature: eidas-connector-node-smoke-test-it-prod
+Feature: eIDAS Connector Node Smoke Test - Italy - Production
 
     This tests the connection of the UK Connector Node to the Italian Proxy Node
 

--- a/features/smoke/eidas_connector_node/production/luxembourg.feature
+++ b/features/smoke/eidas_connector_node/production/luxembourg.feature
@@ -1,4 +1,4 @@
-Feature: eidas-connector-node-smoke-test-lu-prod
+Feature: eIDAS Connector Node Smoke Test - Luxembourg - Production
 
     This tests the connection of the UK Connector Node to the Luxembourg Proxy Node
 

--- a/features/smoke/eidas_connector_node/production/portugal.feature
+++ b/features/smoke/eidas_connector_node/production/portugal.feature
@@ -1,4 +1,4 @@
-Feature: eidas-connector-node-smoke-test-pt-prod
+Feature: eIDAS Connector Node Smoke Test - Portugal - Production
 
     This tests the connection of the UK Connector Node to the Portuguese Proxy Node
 

--- a/features/smoke/eidas_connector_node/production/spain.feature
+++ b/features/smoke/eidas_connector_node/production/spain.feature
@@ -1,4 +1,4 @@
-Feature: eidas-connector-node-smoke-test-es-prod
+Feature: eIDAS Connector Node Smoke Test - Spain - Production
 
     This tests the connection of the UK Connector Node to the Spanish Proxy Node
 


### PR DESCRIPTION
To make them consistent with Proxy Node tests and enable country status reporting the Proxy Node from alphagov/verify-terraform#1231

  - Move to a common file structure
  - Rename to use country names