### PR TITLE
Reduce the size of the built docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM ruby:2.6.5
+FROM ruby:2.6.5 as bundler
 
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 
 RUN bundle install
+
+
+FROM ruby:2.6.5-slim
+
+RUN apt-get update && apt-get install --no-install-recommends -y libxml2 libxslt1.1
+
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
 
 COPY features /features
 


### PR DESCRIPTION
The verify-acceptance-tests docker image is quite large right now.
This means that concourse does a lot of work copying it around.

This does three things to reduce the image size:

 - use the `ruby:2.6.5-slim` image as base, which is smaller
 - add the `--no-install-recommends` option to `apt-get install` to
   avoid installing extra dependencies we don't need
 - use multi-stage docker builds so that we don't include build
   dependencies (like gcc) in the final artefact

This reduces the size from ~900Mb to ~190Mb.

I tried to test this locally, but ./run-tests-with-docker.sh is broken
for me on master: every test fails with:

```
  other os error
  Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:25:53'
  System info: host: '8eccfd00f531', ip: '172.24.0.5', os.name: 'Linux', os.arch: 'amd64', os.version: '4.19.76-linuxkit', java.version: '1.8.0_242'
  Driver info: driver.version: unknown
  remote stacktrace:  (Selenium::WebDriver::Error::UnknownError)
  [remote server] sun.reflect.NativeConstructorAccessorImpl(NativeConstructorAccessorImpl.java):-2:in `newInstance0'
  [remote server] sun.reflect.NativeConstructorAccessorImpl(NativeConstructorAccessorImpl.java):62:in `newInstance'
  [remote server] sun.reflect.DelegatingConstructorAccessorImpl(DelegatingConstructorAccessorImpl.java):45:in `newInstance'
  [remote server] java.lang.reflect.Constructor(Constructor.java):423:in `newInstance'
  [remote server] org.openqa.selenium.remote.W3CHandshakeResponse(W3CHandshakeResponse.java):62:in `lambda$errorHandler$0'
```