### PR TITLE
HUB-697: Add MSA 5.0.2 to backwards compatibility tests

### DIFF
--- a/features/backward_compatibility.feature
+++ b/features/backward_compatibility.feature
@@ -16,3 +16,4 @@ Feature: Compatibility with old supported MSA versions
     | https://test-rp-staging-backcompat-1.cloudapps.digital/test-rp/ |
     | https://test-rp-staging-backcompat-2.cloudapps.digital/test-rp/ |
     | https://test-rp-staging-backcompat-3.cloudapps.digital/test-rp/ |
+    | https://test-rp-staging-backcompat-4.cloudapps.digital/test-rp/ |


### PR DESCRIPTION
See these PR's on the MSA https://github.com/alphagov/verify-matching-service-adapter/pull/166 and infrastructure config https://github.com/alphagov/verify-infrastructure-config/pull/382 to add the config and infrastructure to allow these tests to run.