### PR TITLE
BAU - Fix Estonia smoketest

### DIFF
--- a/features/smoke/eidas_connector_node/integration/estonia.feature
+++ b/features/smoke/eidas_connector_node/integration/estonia.feature
@@ -8,7 +8,7 @@ Feature: eIDAS Connector Node Smoke Test - Estonia - Integration
         And     they start an eIDAS journey
         And     they select 'ID-kaart' scheme
         And     they navigate through the eIDAS CEF reference implementation node
-        And     they click button "ENGLISH"
+        And     they click on link "ENGLISH"
         Then    they should arrive at a page with text 'Secure authentication in e-Services of EU member states'
         And     the page should not have an error message
         And     they click button "Mobile-ID"

--- a/features/smoke/eidas_connector_node/production/estonia.feature
+++ b/features/smoke/eidas_connector_node/production/estonia.feature
@@ -8,6 +8,6 @@ Feature: eIDAS Connector Node Smoke Test - Estonia - Production
         And     they choose to sign in with a digital identity from another European country
         And     they select 'ID-kaart' scheme
         And     they navigate through the eIDAS CEF reference implementation node
-        And     they click button "ENGLISH"
+        And     they click on link "ENGLISH"
         Then    they should arrive at a page with text 'Secure authentication for e-services'
         And     the page should not have an error message


### PR DESCRIPTION
It would appear (from viewing failed test reports sent from the pipeline to Slack 😉) that Estonia's smoketest is failing because what was a button is no longer a button, so:

Change `they click button "ENGLISH"` to `they click on link "ENGLISH"`