### PR TITLE
Remove CEF reference steps for Estonia

### DIFF
--- a/features/smoke/eidas_connector_node/integration/estonia.feature
+++ b/features/smoke/eidas_connector_node/integration/estonia.feature
@@ -7,7 +7,6 @@ Feature: eIDAS Connector Node Smoke Test - Estonia - Integration
         Given   the user is at Test RP
         And     they start an eIDAS journey
         And     they select 'ID-kaart' scheme
-        And     they navigate through the eIDAS CEF reference implementation node
         And     they click button "ENGLISH"
         Then    they should arrive at a page with text 'Secure authentication in e-Services of EU member states'
         And     the page should not have an error message

--- a/features/smoke/eidas_connector_node/production/estonia.feature
+++ b/features/smoke/eidas_connector_node/production/estonia.feature
@@ -7,7 +7,6 @@ Feature: eIDAS Connector Node Smoke Test - Estonia - Production
         Given   the user visits a UK Government service
         And     they choose to sign in with a digital identity from another European country
         And     they select 'ID-kaart' scheme
-        And     they navigate through the eIDAS CEF reference implementation node
         And     they click button "ENGLISH"
         Then    they should arrive at a page with text 'Secure authentication for e-services'
         And     the page should not have an error message


### PR DESCRIPTION
Removes smoke test steps that click through the CEF reference implementation for Estonia. Apparently Estonia doesn't show these pages to users, or require them to click anything. There's a quick redirect and that's all.