### PR TITLE
BAU: Fix Belgian connector-node smoke tests

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -602,7 +602,7 @@ end
 
 And('the page should not have an error message') do
   assert_no_text(/error/i)
-  assert_no_text(/problem/i)
+  assert_no_text(/problem\b/i)
 end
 
 And('they navigate through the eIDAS CEF reference implementation node') do


### PR DESCRIPTION
The Belgians have added a new banner to their landing page (see below) which
includes the work "problems". This matches with our error checking step
which has a regex for "problem".

This commit adds a word boundary to the regex so we don't match the
plural. This is a bit fragile, but it at least preserves some of the
functionality.


![Screenshot 2020-11-09 at 09 32 04](https://user-images.githubusercontent.com/13836290/98523995-86e78980-226e-11eb-95a7-7a5987efcec9.png)
