### PR TITLE
BAU: Fix Estonia connector node test

### DIFF
--- a/features/smoke/eidas_connector_node/integration/estonia.feature
+++ b/features/smoke/eidas_connector_node/integration/estonia.feature
@@ -7,7 +7,7 @@ Feature: eIDAS Connector Node Smoke Test - Estonia - Integration
         Given   the user is at Test RP
         And     they start an eIDAS journey
         And     they select 'ID-kaart' scheme
-        And     they click button "ENGLISH"
+        And     they click "ENGLISH"
         Then    they should arrive at a page with text 'Secure authentication in e-Services of EU member states'
         And     the page should not have an error message
         And     they click button "Mobile-ID"

--- a/features/smoke/eidas_connector_node/production/estonia.feature
+++ b/features/smoke/eidas_connector_node/production/estonia.feature
@@ -7,6 +7,6 @@ Feature: eIDAS Connector Node Smoke Test - Estonia - Production
         Given   the user visits a UK Government service
         And     they choose to sign in with a digital identity from another European country
         And     they select 'ID-kaart' scheme
-        And     they click button "ENGLISH"
+        And     they click "ENGLISH"
         Then    they should arrive at a page with text 'Secure authentication for e-services'
         And     the page should not have an error message

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -164,8 +164,8 @@ Given('they select eIDAS scheme {string}') do |scheme|
   click_on('Select ' + scheme)
 end
 
-Given('they click Register') do
-  click_on('Register')
+Given('they click {string}') do |string|
+  click_on(string)
 end
 
 Given(/^they login as "(.*)"( with a random pid)?$/) do |user_string, with_random_pid|


### PR DESCRIPTION
It's a link, not a button, to change the language to English.

This fixes prod but integration is broken from some sort of SAML'y
reason.