### PR TITLE
BAU: Correctly use refactored step

### DIFF
--- a/features/eidas_journeys_account_creation.feature
+++ b/features/eidas_journeys_account_creation.feature
@@ -8,7 +8,7 @@ Feature: eIDAS user journeys with user account creation
     And we do not want to match the user
     And they start an eIDAS journey
     And they select IDP "Stub IDP Demo"
-    And they click Register
+    And they click "Register"
     And they enter eIDAS user details:
       | firstname   | Bob        |
       | surname     | Doe        |
@@ -39,7 +39,7 @@ Feature: eIDAS user journeys with user account creation
     And they start an eIDAS journey
     And they select IDP "Stub IDP Demo"
     And they choose unsigned assertions
-    And they click Register
+    And they click "Register"
     And they enter eIDAS user details:
       | firstname   | Bob        |
       | surname     | Doe        |

--- a/features/pause_and_resume.feature
+++ b/features/pause_and_resume.feature
@@ -16,7 +16,7 @@ Feature: Pause and Resume User Journey
     Then they will be at the resume page for "Stub Idp Demo Two"
 
     When they resume registering with IDP "Stub Idp Demo Two"
-    And they click Register
+    And they click "Register"
     And they submit user details:
         | firstname       | Jane       |
         | surname         | Doe        |
@@ -42,7 +42,7 @@ Feature: Pause and Resume User Journey
     Then they will be at the resume page for "Stub Idp Demo Two"
 
     When they resume registering with IDP "Stub Idp Demo Two"
-    And they click Register
+    And they click "Register"
     And they submit user details:
       | firstname       | Jane       |
       | surname         | Doe        |
@@ -65,7 +65,7 @@ Feature: Pause and Resume User Journey
     Then they will be at the resume page for "Stub Idp Demo Two"
 
     When they resume registering with IDP "Stub Idp Demo Two"
-    And they click Register
+    And they click "Register"
     And they submit user details:
       | firstname       | Jane       |
       | surname         | Doe        |


### PR DESCRIPTION
The string that matches the placeholder needs to be quoted, otherwise it
assumes there is a step with that literal name.