### PR TITLE
BAU: Remove use of Selenium grid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN bundle install
 
 FROM ghcr.io/alphagov/verify/ruby:2.6.6
 
-RUN apt-get update && apt-get install --no-install-recommends -y libxml2 libxslt1.1
+RUN apt-get update && apt-get install --no-install-recommends -y libxml2 libxslt1.1 firefox-esr
 
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,24 +11,14 @@ show_browser = ENV['SHOW_BROWSER'] == 'true'
 
 ### Driver config ###
 
-if ENV.key?('SELENIUM_HUB_URL')
-  selenium_hub_url    = "#{ENV.fetch('SELENIUM_HUB_URL')}/wd/hub"
-  caps                = Selenium::WebDriver::Remote::Capabilities.firefox
-  Capybara.run_server = false
-
-  Capybara.register_driver :remote_browser do |app|
-    Capybara::Selenium::Driver.new(
-        app,
-        :browser => :remote,
-        url: selenium_hub_url,
-        desired_capabilities: caps
-    )
+if ENV['RUNNING_IN_DOCKER']
+  selenium_hub_url = 'http://selenium-hub:4444/wd/hub'
+  Capybara.register_driver :selenium_remote_firefox do |app|
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox)
   end
 
-  Capybara.default_driver    = :remote_browser
-  Capybara.javascript_driver = :remote_browser
-elsif ENV['TEST_ENV'] == 'local' || ENV['SHOW_BROWSER']
-
+  Capybara.javascript_driver = :selenium_remote_firefox
+else
   if ENV['BROWSER'] == 'chrome'
     browser = :chrome
     options = ::Selenium::WebDriver::Chrome::Options.new
@@ -43,14 +33,6 @@ elsif ENV['TEST_ENV'] == 'local' || ENV['SHOW_BROWSER']
   end
 
   Capybara.javascript_driver = :driver
-
-else
-  selenium_hub_url = 'http://selenium-hub:4444/wd/hub'
-  Capybara.register_driver :selenium_remote_firefox do |app|
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox)
-  end
-
-  Capybara.javascript_driver = :selenium_remote_firefox
 end
 
 Capybara.default_driver = Capybara.javascript_driver

--- a/run-tests-with-docker.sh
+++ b/run-tests-with-docker.sh
@@ -10,6 +10,7 @@ sleep $((2+NODES))
 docker-compose run \
                --name verify-tests \
                -e TEST_ENV="${TEST_ENV:-"staging"}" \
+               -e RUNNING_IN_DOCKER=true \
                verify-tests -n $NODES -o "--strict -f pretty -f junit -o testreport/ --tags 'not @Eidas' $*"
 exit_status=$?
 docker cp "$(docker ps -a -q -f name='verify-tests')":/testreport .


### PR DESCRIPTION
You can see these changes running in Concourse here: https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-verify-hub/jobs/test-hub-staging-tinkering/builds/9

We've found recently that the Selenium grid running in ECS has been very
unreliable and has prevented releases from progressing though the hub
pipeline. Acceptance tests would often timeout, amongst other errors.
The grid shows high use of memory and CPU which could be a contributing
factor. Attempts to diagnose the reason for this flakiness have been
fruitless.

This commit switches to using a local firefox driver. This seems to work
reliably, and means if we can stop using the grid we have one less thing
to maintain/worry about.

The logic is slightly re-ordered in the `env.rb` file so that the case
when we're running in Docker is the special case that uses a Selenium
grid (see the docker-compose file).