### PR TITLE
BAU: Ignore backwards compatibility tests

### DIFF
--- a/features/backward_compatibility.feature
+++ b/features/backward_compatibility.feature
@@ -1,4 +1,4 @@
-@staging-only
+@ignore
 Feature: Compatibility with old supported MSA versions
   These tests check that the hub works correctly with old supported
   MSA versions.


### PR DESCRIPTION
They're blocking the pipeline and are redundant at the moment due to all
MSAs being upgraded recently