### PR TITLE
HUB-812: Remove redundant back compat tests

### DIFF
--- a/features/backward_compatibility.feature
+++ b/features/backward_compatibility.feature
@@ -1,4 +1,4 @@
-@ignore
+@staging-only
 Feature: Compatibility with old supported MSA versions
   These tests check that the hub works correctly with old supported
   MSA versions.
@@ -13,7 +13,5 @@ Feature: Compatibility with old supported MSA versions
 
   Examples:
     | RP                                                              |
-    | https://test-rp-staging-backcompat-1.cloudapps.digital/test-rp/ |
-    | https://test-rp-staging-backcompat-2.cloudapps.digital/test-rp/ |
-    | https://test-rp-staging-backcompat-3.cloudapps.digital/test-rp/ |
-    | https://test-rp-staging-backcompat-4.cloudapps.digital/test-rp/ |
+    | https://test-rp-staging-backcompat-3.cloudapps.digital/test-rp/ | # Version 4.2.1-901
+    | https://test-rp-staging-backcompat-4.cloudapps.digital/test-rp/ | # Version 5.0.2-5.0.2


### PR DESCRIPTION
All services were recently asked to upgrade their MSA. All MSAs in the
wild are now running version 5.0.2-5.0.2 except for two.

One of the other two is still on 4.2.1-901 but have updated their trust
stores to be useable with the new G3 PKI. The other service appears to
be using version 4.1.0 but is not responding to communications to
upgrade.

We have changed the signing certificates used by stub-idp in staging and
integration to the certs from the dev-pki PKI. The trust stores included
with versions of the MSA before 5.0.2 do not include the dev-pki PKI CA
certs and as such will no longer work in integration. Because of this we
should no longer support them.

Version 4.2.1 is being left here as we know we have one service using it
with upgraded trust stores.

We will soon be rolling out the G3 PKI in integration and prod, which
will have the same effect as the dev-pki with regards to backwards
compatibility, except it will affect prod too. Another reason to no
longer support these old version.