### PR TITLE
BAU Use vendored selenium hub and firefox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     build: .
 
   selenium-hub:
-    image: selenium/hub
+    image: ghcr.io/alphagov/verify/selenium-hub
     ports:
       - "4444:4444"
 
   firefoxnode:
-    image: selenium/node-firefox
+    image: ghcr.io/alphagov/verify/selenium-node-firefox
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT_4444_TCP_PORT=4444

--- a/run-tests-with-docker.sh
+++ b/run-tests-with-docker.sh
@@ -11,6 +11,7 @@ docker-compose run \
                --name verify-tests \
                -e TEST_ENV="${TEST_ENV:-"staging"}" \
                -e RUNNING_IN_DOCKER=true \
+               -e CUCUMBER_PUBLISH_QUIET=true \
                verify-tests -n $NODES -o "--strict -f pretty -f junit -o testreport/ --tags 'not @Eidas' $*"
 exit_status=$?
 docker cp "$(docker ps -a -q -f name='verify-tests')":/testreport .


### PR DESCRIPTION
We [vendored](https://github.com/alphagov/verify-terraform/pull/1429) selenium hub and node-firefox.

Mitigate [docker hub rate limits](https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-stubs/jobs/staging-acceptance-tests/builds/81) by using these vendored ghcr.io images.

Tested locally with `./run-tests-with-docker.sh`.