### PR TITLE
[HUB-841] Use Docker Hub rather than GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM ghcr.io/alphagov/verify/ruby:2.6.6 as bundler
+ARG base_image=ruby:2.6.6
+FROM ${base_image} as bundler
 
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 
 RUN bundle install
 
-FROM ghcr.io/alphagov/verify/ruby:2.6.6
+FROM ${base_image}
 
 RUN apt-get update && apt-get install --no-install-recommends -y libxml2 libxslt1.1 firefox-esr
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     build: .
 
   selenium-hub:
-    image: ghcr.io/alphagov/verify/selenium-hub
+    image: selenium/hub:4.0.0
     ports:
       - "4444:4444"
 
   firefoxnode:
-    image: ghcr.io/alphagov/verify/selenium-node-firefox
+    image: selenium/node-firefox:88.0
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT_4444_TCP_PORT=4444


### PR DESCRIPTION
In order to use dockerhub rather than GHCR we need to pass in the base_image ARG so that we can use it later on in the build.