### PR TITLE
[HUB-841] deploy-stubs requires loaded images

### DIFF
--- a/run-tests-with-docker.sh
+++ b/run-tests-with-docker.sh
@@ -3,6 +3,9 @@ set -u
 
 : "${NODES:=6}"
 
+docker load -i ruby-2.6.6/image.tar
+docker load -i selenium-hub-4.0.0/image.tar
+docker load -i selenium-node-firefox/image.tar
 docker-compose build verify-tests
 docker-compose up -d --scale firefoxnode=$NODES selenium-hub firefoxnode 
 echo "Waiting $((2+NODES)) seconds for the nodes to join the selenium hub"


### PR DESCRIPTION
The run-acceptance-tests is currently failing due to the move back to dockerhub. Normally we'd supply an image arg which is the pre-pulled oci image loaded. However, as this is running in cdind it was overlooked.

In order to rectify this I have included the load commands in the script, these match by name the images that are loaded into the pipeline. Therefore this is a companion to another pull request over at verify-infrastructure-config.

Once the tests pass, I think we should add some documentation over on verify-infrastructure-config to clarify that if the base image names change then these will also need to be changed, else it will fail.

Signed-off-by: Chris Mills <7100370+chriscoffee@users.noreply.github.com>